### PR TITLE
Separate Swapper from Sender (Node)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ slither/
 # Fuzz tests
 crytic-export/
 medusa-corpus/
+
+# Wake
+.wake/

--- a/contracts/AngstromBalancer.sol
+++ b/contracts/AngstromBalancer.sol
@@ -76,6 +76,8 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
     uint256 internal constant _SWAP_EXACT_OUT_TYPE_HASH =
         0xb26cc9223a5f7a414a15401ce11a9ef78c5c9daf4bc40c11e20d3f53cb9d79a5;
 
+    uint256 internal constant _MINIMUM_USER_DATA_LENGTH = 20;
+
     /// @dev Set of active Angstrom validator nodes, authorized to unlock this contract for operations.
     mapping(address node => bool isActive) internal _angstromValidatorNodes;
 
@@ -134,6 +136,11 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
         _;
     }
 
+    modifier withValidUserData(bytes calldata userData) {
+        _ensureUserData(userData);
+        _;
+    }
+
     constructor(
         IVault vault,
         IWETH weth,
@@ -167,7 +174,7 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
             abi.decode(
                 _vault.unlock(
                     abi.encodeCall(
-                        AngstromBalancer.swapExactInHookAngstrom,
+                        AngstromBalancer.swapExactInAngstromHook,
                         SwapExactInHookParams({
                             sender: msg.sender,
                             paths: paths,
@@ -181,26 +188,19 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
             );
     }
 
-    function swapExactInHookAngstrom(
+    function swapExactInAngstromHook(
         SwapExactInHookParams calldata params
     )
         external
         nonReentrant
         onlyVault
+        withValidUserData(params.userData)
         returns (uint256[] memory pathAmountsOut, address[] memory tokensOut, uint256[] memory amountsOut)
     {
-        // validate signature and sender.
-        if (params.userData.length < 20) {
-            revert InvalidSignature();
-        }
-
-        (address payer, bytes memory signature) = _splitUserData(params.userData);
-        // The signature looks well-formed.
         bytes32 digest = _computeDigestSwapExactIn(params.paths);
 
-        if (SignatureCheckerLib.isValidSignatureNow(payer, digest, signature) == false) {
-            revert InvalidSignature();
-        }
+        // This reverts if the signature is invalid.
+        address payer = _extractPayerWithValidSignature(digest, params.userData);
 
         (pathAmountsOut, tokensOut, amountsOut) = _swapExactInHook(params);
 
@@ -227,7 +227,7 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
             abi.decode(
                 _vault.unlock(
                     abi.encodeCall(
-                        AngstromBalancer.swapExactOutHookAngstrom,
+                        AngstromBalancer.swapExactOutAngstromHook,
                         SwapExactOutHookParams({
                             sender: msg.sender,
                             paths: paths,
@@ -241,26 +241,19 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
             );
     }
 
-    function swapExactOutHookAngstrom(
+    function swapExactOutAngstromHook(
         SwapExactOutHookParams calldata params
     )
         external
         nonReentrant
         onlyVault
+        withValidUserData(params.userData)
         returns (uint256[] memory pathAmountsIn, address[] memory tokensIn, uint256[] memory amountsIn)
     {
-        // validate signature and sender.
-        if (params.userData.length < 20) {
-            revert InvalidSignature();
-        }
-
-        (address payer, bytes memory signature) = _splitUserData(params.userData);
-        // The signature looks well-formed.
         bytes32 digest = _computeDigestSwapExactOut(params.paths);
 
-        if (SignatureCheckerLib.isValidSignatureNow(payer, digest, signature) == false) {
-            revert InvalidSignature();
-        }
+        // This reverts if the signature is invalid.
+        address payer = _extractPayerWithValidSignature(digest, params.userData);
 
         (pathAmountsIn, tokensIn, amountsIn) = _swapExactOutHook(params);
 
@@ -497,10 +490,10 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
     function _unlockAngstromWithSignature(bytes memory userData) internal {
         // Queries are always allowed.
         if (_isAngstromUnlocked() == false && EVMCallModeHelpers.isStaticCall() == false) {
-            if (userData.length < 20) {
+            if (userData.length < _MINIMUM_USER_DATA_LENGTH) {
                 revert InvalidSignature();
             } else {
-                (address node, bytes memory signature) = _splitUserData(userData);
+                (address node, bytes memory signature) = _splitUserDataMemory(userData);
                 // The signature looks well-formed. Revert if it doesn't correspond to a registered node.
                 _unlockWithEmptyAttestation(node, signature);
             }
@@ -508,22 +501,14 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
     }
 
     function _computeDigestSwapExactIn(SwapPathExactAmountIn[] memory paths) internal view returns (bytes32) {
-        // First, hash the paths array according to EIP-712
+        // First, hash the paths array according to EIP-712.
         bytes32 pathsHash = _hashSwapExactInPathArray(paths);
+        bytes32 structHash = _computeStructHashWithBlockNumber(_SWAP_EXACT_IN_TYPE_HASH, pathsHash);
 
-        bytes32 swapExactInStructHash;
-        // solhint-disable-next-line no-inline-assembly
-        assembly ("memory-safe") {
-            let ptr := mload(0x40)
-            mstore(ptr, _SWAP_EXACT_IN_TYPE_HASH)
-            mstore(add(ptr, 0x20), pathsHash)
-            mstore(add(ptr, 0x40), number())
-            swapExactInStructHash := keccak256(ptr, 0x60)
-        }
-        return _hashTypedData(swapExactInStructHash);
+        return _hashTypedData(structHash);
     }
 
-    // Helper function to hash the SwapPathExactAmountIn array
+    // Helper function to hash the SwapPathExactAmountIn array.
     function _hashSwapExactInPathArray(SwapPathExactAmountIn[] memory paths) internal pure returns (bytes32) {
         bytes32[] memory pathHashes = new bytes32[](paths.length);
 
@@ -536,8 +521,8 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
 
     // Helper function to hash a single SwapPathExactAmountIn
     function _hashSwapExactInPath(SwapPathExactAmountIn memory path) internal pure returns (bytes32) {
-        // You'll need to define the type hash for SwapPathExactAmountIn
-        // For now, using a simple encoding (adjust based on your EIP-712 schema)
+        // We need to define a type hash for SwapPathExactAmountIn.
+        // For now, using a simple encoding (adjust based on the EIP-712 schema).
         bytes32[] memory stepHashes = new bytes32[](path.steps.length);
 
         for (uint256 i = 0; i < path.steps.length; i++) {
@@ -550,22 +535,28 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
     }
 
     function _computeDigestSwapExactOut(SwapPathExactAmountOut[] memory paths) internal view returns (bytes32) {
-        // First, hash the paths array according to EIP-712
+        // First, hash the paths array according to EIP-712.
         bytes32 pathsHash = _hashSwapExactOutPathArray(paths);
+        bytes32 structHash = _computeStructHashWithBlockNumber(_SWAP_EXACT_OUT_TYPE_HASH, pathsHash);
 
-        bytes32 swapExactOutStructHash;
+        return _hashTypedData(structHash);
+    }
+
+    function _computeStructHashWithBlockNumber(uint256 typeHash, bytes32 contentHash) internal view returns (bytes32) {
+        bytes32 structHash;
         // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             let ptr := mload(0x40)
-            mstore(ptr, _SWAP_EXACT_OUT_TYPE_HASH)
-            mstore(add(ptr, 0x20), pathsHash)
+            mstore(ptr, typeHash)
+            mstore(add(ptr, 0x20), contentHash)
             mstore(add(ptr, 0x40), number())
-            swapExactOutStructHash := keccak256(ptr, 0x60)
+            structHash := keccak256(ptr, 0x60)
         }
-        return _hashTypedData(swapExactOutStructHash);
+
+        return structHash;
     }
 
-    // Helper function to hash the SwapPathExactAmountOut array
+    // Helper function to hash the SwapPathExactAmountOut array.
     function _hashSwapExactOutPathArray(SwapPathExactAmountOut[] memory paths) internal pure returns (bytes32) {
         bytes32[] memory pathHashes = new bytes32[](paths.length);
 
@@ -576,8 +567,10 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
         return keccak256(abi.encodePacked(pathHashes));
     }
 
-    // Helper function to hash a single SwapPathExactAmountOut
+    // Helper function to hash a single SwapPathExactAmountOut.
     function _hashSwapExactOutPath(SwapPathExactAmountOut memory path) internal pure returns (bytes32) {
+        // We need to define a type hash for SwapPathExactAmountOut.
+        // For now, using a simple encoding (adjust based on the EIP-712 schema).
         bytes32[] memory stepHashes = new bytes32[](path.steps.length);
 
         for (uint256 i = 0; i < path.steps.length; i++) {
@@ -590,19 +583,16 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
     }
 
     function _getDigest() internal view returns (bytes32) {
-        bytes32 attestationStructHash;
-        // solhint-disable-next-line no-inline-assembly
-        assembly ("memory-safe") {
-            mstore(0x00, _ATTEST_EMPTY_BLOCK_TYPE_HASH)
-            mstore(0x20, number())
-            attestationStructHash := keccak256(0x00, 0x40)
-        }
-        return _hashTypedData(attestationStructHash);
+        bytes32 structHash = _computeStructHashWithBlockNumber(
+            _ATTEST_EMPTY_BLOCK_TYPE_HASH,
+            bytes32(0) // no content for empty attestation
+        );
+        return _hashTypedData(structHash);
     }
 
     // The first 20 bytes of the user data is the node address; the rest is the signature.
     // This function separates the two so that the node signature can be verified.
-    function _splitUserData(
+    function _splitUserDataMemory(
         bytes memory userData
     ) internal pure returns (address extractedAddress, bytes memory hashedMessage) {
         uint256 signatureLength = userData.length - 20;
@@ -618,6 +608,13 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
             // The remaining bytes are the hashed message. 52 is 32 + 20 (length + address length).
             mcopy(add(hashedMessage, 32), add(userData, 52), signatureLength)
         }
+    }
+
+    function _splitUserData(
+        bytes calldata userData
+    ) internal pure returns (address extractedAddress, bytes calldata signature) {
+        extractedAddress = address(bytes20(userData[0:20]));
+        signature = userData[20:];
     }
 
     // Signature passed in memory (from userData).
@@ -647,6 +644,25 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
         // Only one manual unlock or direct swap is permitted per block.
         if (_isAngstromUnlocked()) {
             revert OnlyOncePerBlock();
+        }
+    }
+
+    function _ensureUserData(bytes calldata userData) internal pure {
+        // Basic length validation of the user data, before splitting and signature validation.
+        if (userData.length < _MINIMUM_USER_DATA_LENGTH) {
+            revert InvalidSignature();
+        }
+    }
+
+    function _extractPayerWithValidSignature(
+        bytes32 digest,
+        bytes calldata userData
+    ) internal view returns (address payer) {
+        bytes memory signature;
+        (payer, signature) = _splitUserData(userData);
+
+        if (SignatureCheckerLib.isValidSignatureNow(payer, digest, signature) == false) {
+            revert InvalidSignature();
         }
     }
 

--- a/contracts/AngstromBalancer.sol
+++ b/contracts/AngstromBalancer.sol
@@ -521,17 +521,8 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
 
     // Helper function to hash a single SwapPathExactAmountIn
     function _hashSwapExactInPath(SwapPathExactAmountIn memory path) internal pure returns (bytes32) {
-        // We need to define a type hash for SwapPathExactAmountIn.
-        // For now, using a simple encoding (adjust based on the EIP-712 schema).
-        bytes32[] memory stepHashes = new bytes32[](path.steps.length);
-
-        for (uint256 i = 0; i < path.steps.length; i++) {
-            stepHashes[i] = keccak256(abi.encode(path.steps[i].pool, path.steps[i].tokenOut, path.steps[i].isBuffer));
-        }
-
-        bytes32 stepsHash = keccak256(abi.encodePacked(stepHashes));
-
-        return keccak256(abi.encode(path.tokenIn, stepsHash, path.exactAmountIn, path.minAmountOut));
+        bytes memory stepsBytes = abi.encode(path.steps);
+        return keccak256(abi.encode(path.tokenIn, stepsBytes, path.exactAmountIn, path.minAmountOut));
     }
 
     function _computeDigestSwapExactOut(SwapPathExactAmountOut[] memory paths) internal view returns (bytes32) {

--- a/contracts/AngstromBalancer.sol
+++ b/contracts/AngstromBalancer.sol
@@ -68,6 +68,14 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
     uint256 internal constant _ATTEST_EMPTY_BLOCK_TYPE_HASH =
         0x3f25e551746414ff93f076a7dd83828ff53735b39366c74015637e004fcb0223;
 
+    /// @dev `keccak256("SwapExactIn(SwapPathExactAmountIn[] paths, uint64 block_number)")`.
+    uint256 internal constant _SWAP_EXACT_IN_TYPE_HASH =
+        0xc3810e534961c3152a90c6e5342d0ef3cdd6517c38c42e01b7640beffc3e41c2;
+
+    /// @dev `keccak256("SwapExactOut(SwapPathExactAmountOut[] paths, uint64 block_number)")`.
+    uint256 internal constant _SWAP_EXACT_OUT_TYPE_HASH =
+        0xb26cc9223a5f7a414a15401ce11a9ef78c5c9daf4bc40c11e20d3f53cb9d79a5;
+
     /// @dev Set of active Angstrom validator nodes, authorized to unlock this contract for operations.
     mapping(address node => bool isActive) internal _angstromValidatorNodes;
 
@@ -159,7 +167,7 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
             abi.decode(
                 _vault.unlock(
                     abi.encodeCall(
-                        BatchRouterHooks.swapExactInHook,
+                        AngstromBalancer.swapExactInHookAngstrom,
                         SwapExactInHookParams({
                             sender: msg.sender,
                             paths: paths,
@@ -171,6 +179,32 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
                 ),
                 (uint256[], address[], uint256[])
             );
+    }
+
+    function swapExactInHookAngstrom(
+        SwapExactInHookParams calldata params
+    )
+        external
+        nonReentrant
+        onlyVault
+        returns (uint256[] memory pathAmountsOut, address[] memory tokensOut, uint256[] memory amountsOut)
+    {
+        // validate signature and sender.
+        if (params.userData.length < 20) {
+            revert InvalidSignature();
+        }
+
+        (address payer, bytes memory signature) = _splitUserData(params.userData);
+        // The signature looks well-formed.
+        bytes32 digest = _computeDigestSwapExactIn(params.paths);
+
+        if (SignatureCheckerLib.isValidSignatureNow(payer, digest, signature) == false) {
+            revert InvalidSignature();
+        }
+
+        (pathAmountsOut, tokensOut, amountsOut) = _swapExactInHook(params);
+
+        _settlePaths(payer, params.wethIsEth);
     }
 
     /// @inheritdoc IBatchRouter
@@ -193,7 +227,7 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
             abi.decode(
                 _vault.unlock(
                     abi.encodeCall(
-                        BatchRouterHooks.swapExactOutHook,
+                        AngstromBalancer.swapExactOutHookAngstrom,
                         SwapExactOutHookParams({
                             sender: msg.sender,
                             paths: paths,
@@ -205,6 +239,32 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
                 ),
                 (uint256[], address[], uint256[])
             );
+    }
+
+    function swapExactOutHookAngstrom(
+        SwapExactOutHookParams calldata params
+    )
+        external
+        nonReentrant
+        onlyVault
+        returns (uint256[] memory pathAmountsIn, address[] memory tokensIn, uint256[] memory amountsIn)
+    {
+        // validate signature and sender.
+        if (params.userData.length < 20) {
+            revert InvalidSignature();
+        }
+
+        (address payer, bytes memory signature) = _splitUserData(params.userData);
+        // The signature looks well-formed.
+        bytes32 digest = _computeDigestSwapExactOut(params.paths);
+
+        if (SignatureCheckerLib.isValidSignatureNow(payer, digest, signature) == false) {
+            revert InvalidSignature();
+        }
+
+        (pathAmountsIn, tokensIn, amountsIn) = _swapExactOutHook(params);
+
+        _settlePaths(payer, params.wethIsEth);
     }
 
     /***************************************************************************
@@ -445,6 +505,88 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
                 _unlockWithEmptyAttestation(node, signature);
             }
         }
+    }
+
+    function _computeDigestSwapExactIn(SwapPathExactAmountIn[] memory paths) internal view returns (bytes32) {
+        // First, hash the paths array according to EIP-712
+        bytes32 pathsHash = _hashSwapExactInPathArray(paths);
+
+        bytes32 swapExactInStructHash;
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            mstore(ptr, _SWAP_EXACT_IN_TYPE_HASH)
+            mstore(add(ptr, 0x20), pathsHash)
+            mstore(add(ptr, 0x40), number())
+            swapExactInStructHash := keccak256(ptr, 0x60)
+        }
+        return _hashTypedData(swapExactInStructHash);
+    }
+
+    // Helper function to hash the SwapPathExactAmountIn array
+    function _hashSwapExactInPathArray(SwapPathExactAmountIn[] memory paths) internal pure returns (bytes32) {
+        bytes32[] memory pathHashes = new bytes32[](paths.length);
+
+        for (uint256 i = 0; i < paths.length; i++) {
+            pathHashes[i] = _hashSwapExactInPath(paths[i]);
+        }
+
+        return keccak256(abi.encodePacked(pathHashes));
+    }
+
+    // Helper function to hash a single SwapPathExactAmountIn
+    function _hashSwapExactInPath(SwapPathExactAmountIn memory path) internal pure returns (bytes32) {
+        // You'll need to define the type hash for SwapPathExactAmountIn
+        // For now, using a simple encoding (adjust based on your EIP-712 schema)
+        bytes32[] memory stepHashes = new bytes32[](path.steps.length);
+
+        for (uint256 i = 0; i < path.steps.length; i++) {
+            stepHashes[i] = keccak256(abi.encode(path.steps[i].pool, path.steps[i].tokenOut, path.steps[i].isBuffer));
+        }
+
+        bytes32 stepsHash = keccak256(abi.encodePacked(stepHashes));
+
+        return keccak256(abi.encode(path.tokenIn, stepsHash, path.exactAmountIn, path.minAmountOut));
+    }
+
+    function _computeDigestSwapExactOut(SwapPathExactAmountOut[] memory paths) internal view returns (bytes32) {
+        // First, hash the paths array according to EIP-712
+        bytes32 pathsHash = _hashSwapExactOutPathArray(paths);
+
+        bytes32 swapExactOutStructHash;
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            mstore(ptr, _SWAP_EXACT_OUT_TYPE_HASH)
+            mstore(add(ptr, 0x20), pathsHash)
+            mstore(add(ptr, 0x40), number())
+            swapExactOutStructHash := keccak256(ptr, 0x60)
+        }
+        return _hashTypedData(swapExactOutStructHash);
+    }
+
+    // Helper function to hash the SwapPathExactAmountOut array
+    function _hashSwapExactOutPathArray(SwapPathExactAmountOut[] memory paths) internal pure returns (bytes32) {
+        bytes32[] memory pathHashes = new bytes32[](paths.length);
+
+        for (uint256 i = 0; i < paths.length; i++) {
+            pathHashes[i] = _hashSwapExactOutPath(paths[i]);
+        }
+
+        return keccak256(abi.encodePacked(pathHashes));
+    }
+
+    // Helper function to hash a single SwapPathExactAmountOut
+    function _hashSwapExactOutPath(SwapPathExactAmountOut memory path) internal pure returns (bytes32) {
+        bytes32[] memory stepHashes = new bytes32[](path.steps.length);
+
+        for (uint256 i = 0; i < path.steps.length; i++) {
+            stepHashes[i] = keccak256(abi.encode(path.steps[i].pool, path.steps[i].tokenOut, path.steps[i].isBuffer));
+        }
+
+        bytes32 stepsHash = keccak256(abi.encodePacked(stepHashes));
+
+        return keccak256(abi.encode(path.tokenIn, stepsHash, path.maxAmountIn, path.exactAmountOut));
     }
 
     function _getDigest() internal view returns (bytes32) {

--- a/contracts/test/AngstromBalancerMock.sol
+++ b/contracts/test/AngstromBalancerMock.sol
@@ -6,6 +6,7 @@ import { IPermit2 } from "permit2/src/interfaces/IPermit2.sol";
 
 import { IWETH } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/misc/IWETH.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
+import "@balancer-labs/v3-interfaces/contracts/vault/BatchRouterTypes.sol";
 
 import { AngstromBalancer } from "../AngstromBalancer.sol";
 
@@ -21,6 +22,14 @@ contract AngstromBalancerMock is AngstromBalancer {
 
     function manualUnlockAngstrom() external {
         _unlockAngstrom();
+    }
+
+    function computeDigestSwapExactIn(SwapPathExactAmountIn[] memory paths) external view returns (bytes32) {
+        return _computeDigestSwapExactIn(paths);
+    }
+
+    function computeDigestSwapExactOut(SwapPathExactAmountOut[] memory paths) external view returns (bytes32) {
+        return _computeDigestSwapExactOut(paths);
     }
 
     function getDigest() external view returns (bytes32) {

--- a/test/foundry/AngstromHook.t.sol
+++ b/test/foundry/AngstromHook.t.sol
@@ -42,7 +42,7 @@ contract AngstromHookTest is BaseAngstromTest {
 
     function testOnBeforeSwapInvalidSignature() public {
         // If the signature is invalid, the hook reverts (in this case, signer and key do not match).
-        (, bytes memory userData) = generateSignatureAndUserData(bob, aliceKey);
+        (, bytes memory userData) = generateSignatureAndUserDataEmptyAttestation(bob, aliceKey);
 
         registerAngstromNode(bob);
 
@@ -109,7 +109,7 @@ contract AngstromHookTest is BaseAngstromTest {
     }
 
     function testOnBeforeAddLiquidityUnbalancedInvalidSignature() public {
-        (, bytes memory userData) = generateSignatureAndUserData(alice, bobKey);
+        (, bytes memory userData) = generateSignatureAndUserDataEmptyAttestation(alice, bobKey);
 
         registerAngstromNode(alice);
 
@@ -171,7 +171,7 @@ contract AngstromHookTest is BaseAngstromTest {
     }
 
     function testOnBeforeRemoveLiquidityUnbalancedInvalidSignature() public {
-        (, bytes memory userData) = generateSignatureAndUserData(lp, bobKey);
+        (, bytes memory userData) = generateSignatureAndUserDataEmptyAttestation(lp, bobKey);
 
         registerAngstromNode(lp);
 

--- a/test/foundry/AngstromRouter.t.sol
+++ b/test/foundry/AngstromRouter.t.sol
@@ -41,13 +41,60 @@ contract AngstromRouterTest is BaseAngstromTest {
         angstromBalancer.swapExactIn(paths, MAX_UINT256, false, bytes(""));
     }
 
-    function testSwapExactInUnlocksAngstrom() public {
+    function testSwapExactInAngstromWithoutSignature() public {
         registerAngstromNode(bob);
 
         SwapPathExactAmountIn[] memory paths;
 
         vm.prank(bob);
+        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
         angstromBalancer.swapExactIn(paths, MAX_UINT256, false, bytes(""));
+    }
+
+    function testSwapExactInAngstromPathDifferentFromSignature() public {
+        registerAngstromNode(bob);
+
+        SwapPathStep[] memory steps = new SwapPathStep[](1);
+        steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
+        SwapPathExactAmountIn[] memory paths = new SwapPathExactAmountIn[](1);
+        paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 1e18, minAmountOut: 0 });
+
+        (, bytes memory userData) = generateSignatureAndUserDataSwapExactIn(alice, aliceKey, paths);
+
+        paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 1.01e18, minAmountOut: 0 });
+
+        vm.prank(bob);
+        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        angstromBalancer.swapExactIn(paths, MAX_UINT256, false, userData);
+    }
+
+    function testSwapExactInAngstromBlockNumberDifferentFromSignature() public {
+        registerAngstromNode(bob);
+
+        SwapPathStep[] memory steps = new SwapPathStep[](1);
+        steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
+        SwapPathExactAmountIn[] memory paths = new SwapPathExactAmountIn[](1);
+        paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 1e18, minAmountOut: 0 });
+
+        (, bytes memory userData) = generateSignatureAndUserDataSwapExactIn(alice, aliceKey, paths);
+        // Moving block number should invalidate signature
+        vm.roll(block.number + 1);
+
+        vm.prank(bob);
+        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        angstromBalancer.swapExactIn(paths, MAX_UINT256, false, userData);
+    }
+
+    function testSwapExactInUnlocksAngstrom() public {
+        registerAngstromNode(bob);
+
+        SwapPathExactAmountIn[] memory paths;
+
+        (, bytes memory userData) = generateSignatureAndUserDataSwapExactIn(alice, aliceKey, paths);
+
+        vm.prank(bob);
+        angstromBalancer.swapExactIn(paths, MAX_UINT256, false, userData);
+
         assertEq(
             angstromBalancer.getLastUnlockBlockNumber(),
             block.number,
@@ -72,9 +119,11 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         registerAngstromNode(bob);
 
+        (, bytes memory userData) = generateSignatureAndUserDataSwapExactIn(alice, aliceKey, paths);
+
         vm.prank(bob);
         (uint256[] memory pathAmountsOut, address[] memory tokensOut, uint256[] memory amountsOut) = angstromBalancer
-            .swapExactIn(paths, MAX_UINT256, false, bytes(""));
+            .swapExactIn(paths, MAX_UINT256, false, userData);
 
         assertEq(pathAmountsOut.length, pathAmountsOutQuery.length, "Path amounts out length is not equal");
         assertEq(tokensOut.length, tokensOutQuery.length, "Tokens out length is not equal");
@@ -105,12 +154,75 @@ contract AngstromRouterTest is BaseAngstromTest {
         angstromBalancer.swapExactOut(paths, MAX_UINT256, false, bytes(""));
     }
 
+    function testSwapExactOutAngstromWithoutSignature() public {
+        registerAngstromNode(bob);
+
+        SwapPathExactAmountOut[] memory paths;
+
+        vm.prank(bob);
+        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, bytes(""));
+    }
+
+    function testSwapExactOutAngstromPathDifferentFromSignature() public {
+        registerAngstromNode(bob);
+
+        SwapPathStep[] memory steps = new SwapPathStep[](1);
+        steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
+        SwapPathExactAmountOut[] memory paths = new SwapPathExactAmountOut[](1);
+        paths[0] = SwapPathExactAmountOut({
+            tokenIn: dai,
+            steps: steps,
+            exactAmountOut: 1e18,
+            maxAmountIn: MAX_UINT256
+        });
+
+        (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
+
+        paths[0] = SwapPathExactAmountOut({
+            tokenIn: dai,
+            steps: steps,
+            exactAmountOut: 1.01e18,
+            maxAmountIn: MAX_UINT256
+        });
+
+        vm.prank(bob);
+        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, userData);
+    }
+
+    function testSwapExactOutAngstromBlockNumberDifferentFromSignature() public {
+        registerAngstromNode(bob);
+
+        SwapPathStep[] memory steps = new SwapPathStep[](1);
+        steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
+        SwapPathExactAmountOut[] memory paths = new SwapPathExactAmountOut[](1);
+        paths[0] = SwapPathExactAmountOut({
+            tokenIn: dai,
+            steps: steps,
+            exactAmountOut: 1e18,
+            maxAmountIn: MAX_UINT256
+        });
+
+        (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
+        // Moving block number should invalidate signature
+        vm.roll(block.number + 1);
+
+        vm.prank(bob);
+        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, userData);
+    }
+
     function testSwapExactOutUnlocksRouter() public {
         registerAngstromNode(bob);
 
         SwapPathExactAmountOut[] memory paths;
+
+        (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
+
         vm.prank(bob);
-        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, userData);
+
         assertEq(
             angstromBalancer.getLastUnlockBlockNumber(),
             block.number,
@@ -140,9 +252,11 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         registerAngstromNode(bob);
 
+        (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
+
         vm.prank(bob);
         (uint256[] memory pathAmountsIn, address[] memory tokensIn, uint256[] memory amountsIn) = angstromBalancer
-            .swapExactOut(paths, MAX_UINT256, false, bytes(""));
+            .swapExactOut(paths, MAX_UINT256, false, userData);
 
         assertEq(pathAmountsIn.length, pathAmountsInQuery.length, "Path amounts in length is not equal");
         assertEq(tokensIn.length, tokensInQuery.length, "Tokens in length is not equal");

--- a/test/foundry/utils/BaseAngstromTest.sol
+++ b/test/foundry/utils/BaseAngstromTest.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
+import "@balancer-labs/v3-interfaces/contracts/vault/BatchRouterTypes.sol";
+
 import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
 
 import { AngstromBalancerMock } from "../../../contracts/test/AngstromBalancerMock.sol";
@@ -26,9 +28,9 @@ contract BaseAngstromTest is BaseVaultTest {
     function setUp() public virtual override {
         BaseVaultTest.setUp();
 
-        (aliceSignature, aliceUserData) = generateSignatureAndUserData(alice, aliceKey);
-        (bobSignature, bobUserData) = generateSignatureAndUserData(bob, bobKey);
-        (lpSignature, lpUserData) = generateSignatureAndUserData(lp, lpKey);
+        (aliceSignature, aliceUserData) = generateSignatureAndUserDataEmptyAttestation(alice, aliceKey);
+        (bobSignature, bobUserData) = generateSignatureAndUserDataEmptyAttestation(bob, bobKey);
+        (lpSignature, lpUserData) = generateSignatureAndUserDataEmptyAttestation(lp, lpKey);
     }
 
     function createHook() internal override returns (address) {
@@ -68,11 +70,33 @@ contract BaseAngstromTest is BaseVaultTest {
         assertFalse(angstromBalancer.isRegisteredNode(account), "Node registration failed");
     }
 
-    function generateSignatureAndUserData(
+    function generateSignatureAndUserDataEmptyAttestation(
         address signer,
         uint256 privateKey
     ) internal view returns (bytes memory signature, bytes memory userData) {
         bytes32 hash = angstromBalancer.getDigest();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, hash);
+        signature = abi.encodePacked(r, s, v);
+        userData = abi.encodePacked(signer, signature);
+    }
+
+    function generateSignatureAndUserDataSwapExactIn(
+        address signer,
+        uint256 privateKey,
+        SwapPathExactAmountIn[] memory paths
+    ) internal view returns (bytes memory signature, bytes memory userData) {
+        bytes32 hash = angstromBalancer.computeDigestSwapExactIn(paths);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, hash);
+        signature = abi.encodePacked(r, s, v);
+        userData = abi.encodePacked(signer, signature);
+    }
+
+    function generateSignatureAndUserDataSwapExactOut(
+        address signer,
+        uint256 privateKey,
+        SwapPathExactAmountOut[] memory paths
+    ) internal view returns (bytes memory signature, bytes memory userData) {
+        bytes32 hash = angstromBalancer.computeDigestSwapExactOut(paths);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, hash);
         signature = abi.encodePacked(r, s, v);
         userData = abi.encodePacked(signer, signature);


### PR DESCRIPTION
# Description

When a node calls AngstromBalancer as a router, the swapper is different from msg.sender. Therefore, we need a few things in place:

* Charge and send the funds to the actual swapper, and not the node (msg.sender)
* Validate a signature of the hashed swap path, signed by the swapper

This is a first version, supporting only one swapper per router call, so it does not fulfill the issue #8 completely.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

