### PR TITLE
Support multiple swappers of ToB request

### DIFF
--- a/contracts/AngstromBalancer.sol
+++ b/contracts/AngstromBalancer.sol
@@ -123,7 +123,8 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
                                        Swaps
     ***************************************************************************/
 
-    function swapExactIn(
+    /// @inheritdoc IAngstromBalancer
+    function swapExactInAngstrom(
         SwapPathExactAmountIn[] memory pathsToB,
         ToBSwapData[] memory tobSwaps,
         uint256 deadline,
@@ -135,29 +136,24 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         onlyValidatorNode
         onlyWhenLocked
         saveSender(msg.sender)
-        returns (uint256[] memory pathAmountsOut, address[] memory tokensOut, uint256[] memory amountsOut)
     {
         _unlockAngstrom();
 
-        return
-            abi.decode(
-                _vault.unlock(
-                    abi.encodeCall(
-                        AngstromBalancer.swapExactInAngstromHook,
-                        (
-                            SwapExactInHookParams({
-                                sender: msg.sender,
-                                paths: pathsToB,
-                                deadline: deadline,
-                                wethIsEth: wethIsEth,
-                                userData: userData
-                            }),
-                            tobSwaps
-                        )
-                    )
-                ),
-                (uint256[], address[], uint256[])
-            );
+        _vault.unlock(
+            abi.encodeCall(
+                AngstromBalancer.swapExactInAngstromHook,
+                (
+                    SwapExactInHookParams({
+                        sender: msg.sender,
+                        paths: pathsToB,
+                        deadline: deadline,
+                        wethIsEth: wethIsEth,
+                        userData: userData
+                    }),
+                    tobSwaps
+                )
+            )
+        );
     }
 
     function swapExactInAngstromHook(
@@ -182,7 +178,8 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         _settleToBPath(tobSwaps, params.wethIsEth);
     }
 
-    function swapExactOut(
+    /// @inheritdoc IAngstromBalancer
+    function swapExactOutAngstrom(
         SwapPathExactAmountOut[] memory pathsToB,
         ToBSwapData[] memory tobSwaps,
         uint256 deadline,
@@ -194,29 +191,24 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         onlyValidatorNode
         onlyWhenLocked
         saveSender(msg.sender)
-        returns (uint256[] memory pathAmountsIn, address[] memory tokensIn, uint256[] memory amountsIn)
     {
         _unlockAngstrom();
 
-        return
-            abi.decode(
-                _vault.unlock(
-                    abi.encodeCall(
-                        AngstromBalancer.swapExactOutAngstromHook,
-                        (
-                            SwapExactOutHookParams({
-                                sender: msg.sender,
-                                paths: pathsToB,
-                                deadline: deadline,
-                                wethIsEth: wethIsEth,
-                                userData: userData
-                            }),
-                            tobSwaps
-                        )
-                    )
-                ),
-                (uint256[], address[], uint256[])
-            );
+        _vault.unlock(
+            abi.encodeCall(
+                AngstromBalancer.swapExactOutAngstromHook,
+                (
+                    SwapExactOutHookParams({
+                        sender: msg.sender,
+                        paths: pathsToB,
+                        deadline: deadline,
+                        wethIsEth: wethIsEth,
+                        userData: userData
+                    }),
+                    tobSwaps
+                )
+            )
+        );
     }
 
     function swapExactOutAngstromHook(
@@ -239,75 +231,6 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         (pathAmountsIn, tokensIn, amountsIn) = _swapExactOutHook(params);
 
         _settleToBPath(tobSwaps, params.wethIsEth);
-    }
-
-    /***************************************************************************
-                                     Queries
-    ***************************************************************************/
-
-    // Note that queries do not require coordination with Angstrom, and can be called by anyone at any time.
-    // We include them here to satisfy the IBatchRouter interface.
-
-    function querySwapExactIn(
-        SwapPathExactAmountIn[] memory paths,
-        address sender,
-        bytes calldata userData
-    )
-        external
-        saveSender(sender)
-        returns (uint256[] memory pathAmountsOut, address[] memory tokensOut, uint256[] memory amountsOut)
-    {
-        for (uint256 i = 0; i < paths.length; ++i) {
-            paths[i].minAmountOut = 0;
-        }
-
-        return
-            abi.decode(
-                _vault.quote(
-                    abi.encodeCall(
-                        BatchRouterHooks.querySwapExactInHook,
-                        SwapExactInHookParams({
-                            sender: address(this),
-                            paths: paths,
-                            deadline: type(uint256).max,
-                            wethIsEth: false,
-                            userData: userData
-                        })
-                    )
-                ),
-                (uint256[], address[], uint256[])
-            );
-    }
-
-    function querySwapExactOut(
-        SwapPathExactAmountOut[] memory paths,
-        address sender,
-        bytes calldata userData
-    )
-        external
-        saveSender(sender)
-        returns (uint256[] memory pathAmountsIn, address[] memory tokensIn, uint256[] memory amountsIn)
-    {
-        for (uint256 i = 0; i < paths.length; ++i) {
-            paths[i].maxAmountIn = _MAX_AMOUNT;
-        }
-
-        return
-            abi.decode(
-                _vault.quote(
-                    abi.encodeCall(
-                        BatchRouterHooks.querySwapExactOutHook,
-                        SwapExactOutHookParams({
-                            sender: address(this),
-                            paths: paths,
-                            deadline: type(uint256).max,
-                            wethIsEth: false,
-                            userData: userData
-                        })
-                    )
-                ),
-                (uint256[], address[], uint256[])
-            );
     }
 
     /***************************************************************************

--- a/contracts/AngstromBalancer.sol
+++ b/contracts/AngstromBalancer.sol
@@ -130,13 +130,7 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         uint256 deadline,
         bool wethIsEth,
         bytes calldata userData
-    )
-        external
-        payable
-        onlyValidatorNode
-        onlyWhenLocked
-        saveSender(msg.sender)
-    {
+    ) external payable onlyValidatorNode onlyWhenLocked saveSender(msg.sender) {
         _unlockAngstrom();
 
         _vault.unlock(
@@ -185,13 +179,7 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         uint256 deadline,
         bool wethIsEth,
         bytes calldata userData
-    )
-        external
-        payable
-        onlyValidatorNode
-        onlyWhenLocked
-        saveSender(msg.sender)
-    {
+    ) external payable onlyValidatorNode onlyWhenLocked saveSender(msg.sender) {
         _unlockAngstrom();
 
         _vault.unlock(

--- a/contracts/AngstromBalancer.sol
+++ b/contracts/AngstromBalancer.sol
@@ -561,7 +561,7 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         return keccak256(abi.encode(path.tokenIn, stepsHash, path.maxAmountIn, path.exactAmountOut));
     }
 
-    function _getDigest() internal view returns (bytes32) {
+    function _computeDigestEmptyAttestation() internal view returns (bytes32) {
         bytes32 structHash = _computeStructHashWithBlockNumber(
             _ATTEST_EMPTY_BLOCK_TYPE_HASH,
             bytes32(0) // no content for empty attestation
@@ -629,7 +629,7 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
     function _ensureRegisteredNodeAndReturnDigest(address account) internal view returns (bytes32) {
         _ensureRegisteredNode(account);
 
-        return _getDigest();
+        return _computeDigestEmptyAttestation();
     }
 
     function _ensureRegisteredNode(address account) internal view {

--- a/contracts/AngstromBalancer.sol
+++ b/contracts/AngstromBalancer.sol
@@ -6,9 +6,7 @@ import { SignatureCheckerLib } from "solady/src/utils/SignatureCheckerLib.sol";
 import { IPermit2 } from "permit2/src/interfaces/IPermit2.sol";
 import { EIP712 } from "solady/src/utils/EIP712.sol";
 
-import { IBatchRouterQueries } from "@balancer-labs/v3-interfaces/contracts/vault/IBatchRouterQueries.sol";
 import { IWETH } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/misc/IWETH.sol";
-import { IBatchRouter } from "@balancer-labs/v3-interfaces/contracts/vault/IBatchRouter.sol";
 import { IHooks } from "@balancer-labs/v3-interfaces/contracts/vault/IHooks.sol";
 import { IVault } from "@balancer-labs/v3-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v3-interfaces/contracts/vault/BatchRouterTypes.sol";
@@ -17,6 +15,12 @@ import "@balancer-labs/v3-interfaces/contracts/vault/VaultTypes.sol";
 import { EVMCallModeHelpers } from "@balancer-labs/v3-solidity-utils/contracts/helpers/EVMCallModeHelpers.sol";
 import { OwnableAuthentication } from "@balancer-labs/v3-standalone-utils/contracts/OwnableAuthentication.sol";
 import { BatchRouterHooks } from "@balancer-labs/v3-vault/contracts/BatchRouterHooks.sol";
+import {
+    TransientEnumerableSet
+} from "@balancer-labs/v3-solidity-utils/contracts/openzeppelin/TransientEnumerableSet.sol";
+import {
+    TransientStorageHelpers
+} from "@balancer-labs/v3-solidity-utils/contracts/helpers/TransientStorageHelpers.sol";
 import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
 
 import { IAngstromBalancer } from "./interfaces/IAngstromBalancer.sol";
@@ -65,7 +69,10 @@ import { IAngstromBalancer } from "./interfaces/IAngstromBalancer.sol";
  *
  * See [this diagram](https://drive.google.com/file/d/1A4kNi0ocI_V8tWcy3ruGNf-AaoP04bmR/view?usp=sharing).
  */
-contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, OwnableAuthentication, BaseHooks, EIP712 {
+contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthentication, BaseHooks, EIP712 {
+    using TransientEnumerableSet for TransientEnumerableSet.AddressSet;
+    using TransientStorageHelpers for *;
+
     /// @dev `keccak256("AttestAngstromBlockEmpty(uint64 block_number)")`.
     uint256 internal constant _ATTEST_EMPTY_BLOCK_TYPE_HASH =
         0x3f25e551746414ff93f076a7dd83828ff53735b39366c74015637e004fcb0223;
@@ -77,6 +84,12 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
     /// @dev `keccak256("SwapExactOut(SwapPathExactAmountOut[] paths, uint64 block_number)")`.
     uint256 internal constant _SWAP_EXACT_OUT_TYPE_HASH =
         0xb26cc9223a5f7a414a15401ce11a9ef78c5c9daf4bc40c11e20d3f53cb9d79a5;
+
+    /**
+     * @dev `keccak256("ToBSwap(address tokenIn,address tokenOut,uint256 exactAmountIn,uint256 exactAmountOut,address
+     * payer,uint64 block_number)")`.
+     */
+    uint256 internal constant _TOB_SWAP_TYPE_HASH = 0x33ea2c5351079a10fb30dea7d5e13a7b1a184012f4f990b1ce23e7a65822518f;
 
     uint256 internal constant _MINIMUM_USER_DATA_LENGTH = 20;
 
@@ -115,9 +128,9 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
                                        Swaps
     ***************************************************************************/
 
-    /// @inheritdoc IBatchRouter
     function swapExactIn(
-        SwapPathExactAmountIn[] memory paths,
+        SwapPathExactAmountIn[] memory pathsToB,
+        ToBSwapData[] memory tobSwaps,
         uint256 deadline,
         bool wethIsEth,
         bytes calldata userData
@@ -136,13 +149,16 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
                 _vault.unlock(
                     abi.encodeCall(
                         AngstromBalancer.swapExactInAngstromHook,
-                        SwapExactInHookParams({
-                            sender: msg.sender,
-                            paths: paths,
-                            deadline: deadline,
-                            wethIsEth: wethIsEth,
-                            userData: userData
-                        })
+                        (
+                            SwapExactInHookParams({
+                                sender: msg.sender,
+                                paths: pathsToB,
+                                deadline: deadline,
+                                wethIsEth: wethIsEth,
+                                userData: userData
+                            }),
+                            tobSwaps
+                        )
                     )
                 ),
                 (uint256[], address[], uint256[])
@@ -150,7 +166,8 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
     }
 
     function swapExactInAngstromHook(
-        SwapExactInHookParams calldata params
+        SwapExactInHookParams calldata params,
+        ToBSwapData[] calldata tobSwaps
     )
         external
         nonReentrant
@@ -158,19 +175,22 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
         withValidUserData(params.userData)
         returns (uint256[] memory pathAmountsOut, address[] memory tokensOut, uint256[] memory amountsOut)
     {
-        bytes32 digest = _computeDigestSwapExactIn(params.paths);
+        for (uint256 i = 0; i < tobSwaps.length; i++) {
+            bytes32 digest = _computeDigestToB(tobSwaps[i]);
 
-        // This reverts if the signature is invalid.
-        address payer = _extractPayerWithValidSignature(digest, params.userData);
+            if (SignatureCheckerLib.isValidSignatureNow(tobSwaps[i].payer, digest, tobSwaps[i].signature) == false) {
+                revert InvalidSignature();
+            }
+        }
 
         (pathAmountsOut, tokensOut, amountsOut) = _swapExactInHook(params);
 
-        _settlePaths(payer, params.wethIsEth);
+        _settleToBPath(tobSwaps, params.wethIsEth);
     }
 
-    /// @inheritdoc IBatchRouter
     function swapExactOut(
-        SwapPathExactAmountOut[] memory paths,
+        SwapPathExactAmountOut[] memory pathsToB,
+        ToBSwapData[] memory tobSwaps,
         uint256 deadline,
         bool wethIsEth,
         bytes calldata userData
@@ -189,13 +209,16 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
                 _vault.unlock(
                     abi.encodeCall(
                         AngstromBalancer.swapExactOutAngstromHook,
-                        SwapExactOutHookParams({
-                            sender: msg.sender,
-                            paths: paths,
-                            deadline: deadline,
-                            wethIsEth: wethIsEth,
-                            userData: userData
-                        })
+                        (
+                            SwapExactOutHookParams({
+                                sender: msg.sender,
+                                paths: pathsToB,
+                                deadline: deadline,
+                                wethIsEth: wethIsEth,
+                                userData: userData
+                            }),
+                            tobSwaps
+                        )
                     )
                 ),
                 (uint256[], address[], uint256[])
@@ -203,7 +226,8 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
     }
 
     function swapExactOutAngstromHook(
-        SwapExactOutHookParams calldata params
+        SwapExactOutHookParams calldata params,
+        ToBSwapData[] calldata tobSwaps
     )
         external
         nonReentrant
@@ -211,14 +235,17 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
         withValidUserData(params.userData)
         returns (uint256[] memory pathAmountsIn, address[] memory tokensIn, uint256[] memory amountsIn)
     {
-        bytes32 digest = _computeDigestSwapExactOut(params.paths);
+        for (uint256 i = 0; i < tobSwaps.length; i++) {
+            bytes32 digest = _computeDigestToB(tobSwaps[i]);
 
-        // This reverts if the signature is invalid.
-        address payer = _extractPayerWithValidSignature(digest, params.userData);
+            if (SignatureCheckerLib.isValidSignatureNow(tobSwaps[i].payer, digest, tobSwaps[i].signature) == false) {
+                revert InvalidSignature();
+            }
+        }
 
         (pathAmountsIn, tokensIn, amountsIn) = _swapExactOutHook(params);
 
-        _settlePaths(payer, params.wethIsEth);
+        _settleToBPath(tobSwaps, params.wethIsEth);
     }
 
     /***************************************************************************
@@ -228,7 +255,6 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
     // Note that queries do not require coordination with Angstrom, and can be called by anyone at any time.
     // We include them here to satisfy the IBatchRouter interface.
 
-    /// @inheritdoc IBatchRouterQueries
     function querySwapExactIn(
         SwapPathExactAmountIn[] memory paths,
         address sender,
@@ -260,7 +286,6 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
             );
     }
 
-    /// @inheritdoc IBatchRouterQueries
     function querySwapExactOut(
         SwapPathExactAmountOut[] memory paths,
         address sender,
@@ -551,6 +576,24 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
         return _hashTypedData(structHash);
     }
 
+    function _computeDigestToB(ToBSwapData calldata swapData) internal view returns (bytes32) {
+        bytes32 structHash;
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            mstore(ptr, _TOB_SWAP_TYPE_HASH)
+            mstore(add(ptr, 0x20), calldataload(swapData)) // tokenIn
+            mstore(add(ptr, 0x40), calldataload(add(swapData, 0x20))) // tokenOut
+            mstore(add(ptr, 0x60), calldataload(add(swapData, 0x40))) // exactAmountIn
+            mstore(add(ptr, 0x80), calldataload(add(swapData, 0x60))) // exactAmountOut
+            mstore(add(ptr, 0xa0), calldataload(add(swapData, 0x80))) // payer
+            mstore(add(ptr, 0xc0), number()) // block_number
+            structHash := keccak256(ptr, 0xe0)
+        }
+
+        return _hashTypedData(structHash);
+    }
+
     // The first 20 bytes of the user data is the node address; the rest is the signature.
     // This function separates the two so that the node signature can be verified.
     function _splitUserDataMemory(
@@ -629,5 +672,29 @@ contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, 
 
     function _unlockAngstrom() internal {
         _lastUnlockBlockNumber = block.number;
+    }
+
+    function _settleToBPath(ToBSwapData[] calldata tobSwaps, bool wethIsEth) internal {
+        for (uint256 i = 0; i < tobSwaps.length; ++i) {
+            ToBSwapData calldata swap = tobSwaps[i];
+
+            // Take tokens from the payer or settle if prepaid
+            _takeOrSettle(swap.payer, wethIsEth, swap.tokenIn, swap.exactAmountIn);
+
+            // These parameters are not used for tobSwaps and should be erased in case other swaps happen
+            // in the same transaction using this router.
+            _currentSwapTokenInAmounts().tSet(swap.tokenIn, 0);
+            _currentSwapTokensIn().remove(swap.tokenIn);
+
+            // Send tokens to the payer
+            _sendTokenOut(swap.payer, IERC20(swap.tokenOut), swap.exactAmountOut, wethIsEth);
+
+            // These parameters are not used for tobSwaps and should be erased in case other swaps happen
+            // in the same transaction using this router.
+            _currentSwapTokenOutAmounts().tSet(swap.tokenOut, 0);
+            _currentSwapTokensOut().remove(swap.tokenOut);
+        }
+
+        // TODO: Should _returnEth be implemented here?
     }
 }

--- a/contracts/AngstromBalancer.sol
+++ b/contracts/AngstromBalancer.sol
@@ -110,11 +110,6 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         _;
     }
 
-    modifier withValidUserData(bytes calldata userData) {
-        _ensureUserData(userData);
-        _;
-    }
-
     constructor(
         IVault vault,
         IWETH weth,
@@ -172,7 +167,6 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         external
         nonReentrant
         onlyVault
-        withValidUserData(params.userData)
         returns (uint256[] memory pathAmountsOut, address[] memory tokensOut, uint256[] memory amountsOut)
     {
         for (uint256 i = 0; i < tobSwaps.length; i++) {
@@ -232,7 +226,6 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         external
         nonReentrant
         onlyVault
-        withValidUserData(params.userData)
         returns (uint256[] memory pathAmountsIn, address[] memory tokensIn, uint256[] memory amountsIn)
     {
         for (uint256 i = 0; i < tobSwaps.length; i++) {
@@ -576,17 +569,18 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         return _hashTypedData(structHash);
     }
 
-    function _computeDigestToB(ToBSwapData calldata swapData) internal view returns (bytes32) {
+    function _computeDigestToB(ToBSwapData memory swapData) internal view returns (bytes32) {
         bytes32 structHash;
+
         // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             let ptr := mload(0x40)
             mstore(ptr, _TOB_SWAP_TYPE_HASH)
-            mstore(add(ptr, 0x20), calldataload(swapData)) // tokenIn
-            mstore(add(ptr, 0x40), calldataload(add(swapData, 0x20))) // tokenOut
-            mstore(add(ptr, 0x60), calldataload(add(swapData, 0x40))) // exactAmountIn
-            mstore(add(ptr, 0x80), calldataload(add(swapData, 0x60))) // exactAmountOut
-            mstore(add(ptr, 0xa0), calldataload(add(swapData, 0x80))) // payer
+            mstore(add(ptr, 0x20), mload(swapData)) // tokenIn
+            mstore(add(ptr, 0x40), mload(add(swapData, 0x20))) // tokenOut
+            mstore(add(ptr, 0x60), mload(add(swapData, 0x40))) // exactAmountIn
+            mstore(add(ptr, 0x80), mload(add(swapData, 0x60))) // exactAmountOut
+            mstore(add(ptr, 0xa0), mload(add(swapData, 0x80))) // payer
             mstore(add(ptr, 0xc0), number()) // block_number
             structHash := keccak256(ptr, 0xe0)
         }
@@ -648,13 +642,6 @@ contract AngstromBalancer is IAngstromBalancer, BatchRouterHooks, OwnableAuthent
         // Only one manual unlock or direct swap is permitted per block.
         if (_isAngstromUnlocked()) {
             revert OnlyOncePerBlock();
-        }
-    }
-
-    function _ensureUserData(bytes calldata userData) internal pure {
-        // Basic length validation of the user data, before splitting and signature validation.
-        if (userData.length < _MINIMUM_USER_DATA_LENGTH) {
-            revert InvalidSignature();
         }
     }
 

--- a/contracts/AngstromBalancer.sol
+++ b/contracts/AngstromBalancer.sol
@@ -19,6 +19,8 @@ import { OwnableAuthentication } from "@balancer-labs/v3-standalone-utils/contra
 import { BatchRouterHooks } from "@balancer-labs/v3-vault/contracts/BatchRouterHooks.sol";
 import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
 
+import { IAngstromBalancer } from "./interfaces/IAngstromBalancer.sol";
+
 /**
  * @notice Angstrom Router and Hook, used to trade against Angstrom pools.
  * @dev This contract is a combination of a batch router and a hook, designed to work with pools traded primarily on
@@ -63,7 +65,7 @@ import { BaseHooks } from "@balancer-labs/v3-vault/contracts/BaseHooks.sol";
  *
  * See [this diagram](https://drive.google.com/file/d/1A4kNi0ocI_V8tWcy3ruGNf-AaoP04bmR/view?usp=sharing).
  */
-contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthentication, BaseHooks, EIP712 {
+contract AngstromBalancer is IAngstromBalancer, IBatchRouter, BatchRouterHooks, OwnableAuthentication, BaseHooks, EIP712 {
     /// @dev `keccak256("AttestAngstromBlockEmpty(uint64 block_number)")`.
     uint256 internal constant _ATTEST_EMPTY_BLOCK_TYPE_HASH =
         0x3f25e551746414ff93f076a7dd83828ff53735b39366c74015637e004fcb0223;
@@ -81,47 +83,6 @@ contract AngstromBalancer is IBatchRouter, BatchRouterHooks, OwnableAuthenticati
 
     /// @dev The currently "unlocked" block. The contract is locked if the current block does not equal this number.
     uint256 internal _lastUnlockBlockNumber;
-
-    /**
-     * @notice This contract can only be unlocked once per block.
-     * @dev This should not happen, but could if an Angstrom validator manually unlocks the contract twice, or manually
-     * unlocks in the same block after the Angstrom bundle has been executed, or if there is more than one direct swap
-     * in the bundle.
-     */
-    error OnlyOncePerBlock();
-
-    /**
-     * @notice An account attempted to unlock this contract that was not a registered Angstrom validator.
-     * @dev The node must be registered as an Angstrom node to unlock the contract for operations, either directly or
-     * by executing a permissioned operation. This can also occur for a valid signature, if the node address is
-     * unregistered.
-     */
-    error NotNode();
-
-    /**
-     * @notice The signature provided on a swap or liquidity operation was invalid.
-     * @dev The user provided a signature of the correct length, and the node address is registered, but the hashed
-     * message is wrong.
-     */
-    error InvalidSignature();
-
-    /**
-     * @notice The node was already registered.
-     * @dev The node was already registered as an Angstrom node
-     */
-    error NodeAlreadyRegistered();
-
-    /**
-     * @notice The node was not registered.
-     * @dev The node was not registered as an Angstrom node
-     */
-    error NodeNotRegistered();
-
-    /// @notice A node was registered and is allowed to unlock Angstrom pools.
-    event NodeRegistered(address indexed node);
-
-    /// @notice A node was deregistered and is no longer able to unlock Angstrom pools.
-    event NodeDeregistered(address indexed node);
 
     modifier onlyValidatorNode() {
         // Only Validators can call direct swaps on this router.

--- a/contracts/interfaces/IAngstromBalancer.sol
+++ b/contracts/interfaces/IAngstromBalancer.sol
@@ -81,15 +81,15 @@ interface IAngstromBalancer {
 
     /**
      * @notice Executes a batch swap with pathsToB and pay to swappers according to tobSwaps.
-     * @dev This router executes all Top of Block (ToB) swaps in a single batch router path. ToB swaps have the 
+     * @dev This router executes all Top of Block (ToB) swaps in a single batch router path. ToB swaps have the
      * advantage of executing first in a block, so they know exactly the amount of tokens in and out. Therefore, these
      * swaps can be combined to optimize gas.
      * Notice that this function does not follow the swapExactIn implementation of the IBatchRouter interface. That's
      * because we need to collect and return tokens to the payers in ToB swaps, and not the msg.sender. So, we need
-     * two separate structs: one to describe the swap path, the other to describe amounts to be distributed to each 
+     * two separate structs: one to describe the swap path, the other to describe amounts to be distributed to each
      * payer.
      * Also, notice that this function does not return the tokens out and amounts out.
-     * 
+     *
      * @param pathsToB All ToB swaps combined in a single path
      * @param tobSwaps Structs describing the amounts to be distributed to each payer and payer signatures
      * @param deadline Deadline for the swap, after which it will revert
@@ -102,21 +102,19 @@ interface IAngstromBalancer {
         uint256 deadline,
         bool wethIsEth,
         bytes calldata userData
-    )
-        external
-        payable;
+    ) external payable;
 
     /**
      * @notice Executes a batch swap with pathsToB and pay to swappers according to tobSwaps.
-     * @dev This router executes all Top of Block (ToB) swaps in a single batch router path. ToB swaps have the 
+     * @dev This router executes all Top of Block (ToB) swaps in a single batch router path. ToB swaps have the
      * advantage of executing first in a block, so they know exactly the amount of tokens in and out. Therefore, these
      * swaps can be combined to optimize gas.
      * Notice that this function does not follow the swapExactIn implementation of the IBatchRouter interface. That's
      * because we need to collect and return tokens to the payers in ToB swaps, and not the msg.sender. So, we need
-     * two separate structs: one to describe the swap path, the other to describe amounts to be distributed to each 
+     * two separate structs: one to describe the swap path, the other to describe amounts to be distributed to each
      * payer.
      * Also, notice that this function does not return the tokens out and amounts out.
-     * 
+     *
      * @param pathsToB All ToB swaps combined in a single path
      * @param tobSwaps Structs describing the amounts to be distributed to each payer and payer signatures
      * @param deadline Deadline for the swap, after which it will revert
@@ -129,9 +127,7 @@ interface IAngstromBalancer {
         uint256 deadline,
         bool wethIsEth,
         bytes calldata userData
-    )
-        external
-        payable;
+    ) external payable;
 
     /**
      * @notice Unlocks the Angstrom network without requiring an operation.

--- a/contracts/interfaces/IAngstromBalancer.sol
+++ b/contracts/interfaces/IAngstromBalancer.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.24;
 
+import "@balancer-labs/v3-interfaces/contracts/vault/BatchRouterTypes.sol";
+
 /**
  * @notice Interface for the Angstrom Router and Hook.
  * @dev This interface defines the public API for the AngstromBalancer contract.
@@ -76,6 +78,60 @@ interface IAngstromBalancer {
     /***************************************************************************
                                    Public Functions
     ***************************************************************************/
+
+    /**
+     * @notice Executes a batch swap with pathsToB and pay to swappers according to tobSwaps.
+     * @dev This router executes all Top of Block (ToB) swaps in a single batch router path. ToB swaps have the 
+     * advantage of executing first in a block, so they know exactly the amount of tokens in and out. Therefore, these
+     * swaps can be combined to optimize gas.
+     * Notice that this function does not follow the swapExactIn implementation of the IBatchRouter interface. That's
+     * because we need to collect and return tokens to the payers in ToB swaps, and not the msg.sender. So, we need
+     * two separate structs: one to describe the swap path, the other to describe amounts to be distributed to each 
+     * payer.
+     * Also, notice that this function does not return the tokens out and amounts out.
+     * 
+     * @param pathsToB All ToB swaps combined in a single path
+     * @param tobSwaps Structs describing the amounts to be distributed to each payer and payer signatures
+     * @param deadline Deadline for the swap, after which it will revert
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
+     * @param userData Additional (optional) data required for the swap
+     */
+    function swapExactInAngstrom(
+        SwapPathExactAmountIn[] memory pathsToB,
+        ToBSwapData[] memory tobSwaps,
+        uint256 deadline,
+        bool wethIsEth,
+        bytes calldata userData
+    )
+        external
+        payable;
+
+    /**
+     * @notice Executes a batch swap with pathsToB and pay to swappers according to tobSwaps.
+     * @dev This router executes all Top of Block (ToB) swaps in a single batch router path. ToB swaps have the 
+     * advantage of executing first in a block, so they know exactly the amount of tokens in and out. Therefore, these
+     * swaps can be combined to optimize gas.
+     * Notice that this function does not follow the swapExactIn implementation of the IBatchRouter interface. That's
+     * because we need to collect and return tokens to the payers in ToB swaps, and not the msg.sender. So, we need
+     * two separate structs: one to describe the swap path, the other to describe amounts to be distributed to each 
+     * payer.
+     * Also, notice that this function does not return the tokens out and amounts out.
+     * 
+     * @param pathsToB All ToB swaps combined in a single path
+     * @param tobSwaps Structs describing the amounts to be distributed to each payer and payer signatures
+     * @param deadline Deadline for the swap, after which it will revert
+     * @param wethIsEth If true, incoming ETH will be wrapped to WETH and outgoing WETH will be unwrapped to ETH
+     * @param userData Additional (optional) data required for the swap
+     */
+    function swapExactOutAngstrom(
+        SwapPathExactAmountOut[] memory pathsToB,
+        ToBSwapData[] memory tobSwaps,
+        uint256 deadline,
+        bool wethIsEth,
+        bytes calldata userData
+    )
+        external
+        payable;
 
     /**
      * @notice Unlocks the Angstrom network without requiring an operation.

--- a/contracts/interfaces/IAngstromBalancer.sol
+++ b/contracts/interfaces/IAngstromBalancer.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.8.24;
+
+/**
+ * @notice Interface for the Angstrom Router and Hook.
+ * @dev This interface defines the public API for the AngstromBalancer contract.
+ */
+interface IAngstromBalancer {
+    /***************************************************************************
+                                       Errors
+    ***************************************************************************/
+
+    /**
+     * @notice This contract can only be unlocked once per block.
+     * @dev This should not happen, but could if an Angstrom validator manually unlocks the contract twice, or manually
+     * unlocks in the same block after the Angstrom bundle has been executed, or if there is more than one direct swap
+     * in the bundle.
+     */
+    error OnlyOncePerBlock();
+
+    /**
+     * @notice An account attempted to unlock this contract that was not a registered Angstrom validator.
+     * @dev The node must be registered as an Angstrom node to unlock the contract for operations, either directly or
+     * by executing a permissioned operation. This can also occur for a valid signature, if the node address is
+     * unregistered.
+     */
+    error NotNode();
+
+    /**
+     * @notice The signature provided on a swap or liquidity operation was invalid.
+     * @dev The user provided a signature of the correct length, and the node address is registered, but the hashed
+     * message is wrong.
+     */
+    error InvalidSignature();
+
+    /**
+     * @notice The node was already registered.
+     * @dev The node was already registered as an Angstrom node
+     */
+    error NodeAlreadyRegistered();
+
+    /**
+     * @notice The node was not registered.
+     * @dev The node was not registered as an Angstrom node
+     */
+    error NodeNotRegistered();
+
+    /***************************************************************************
+                                       Events
+    ***************************************************************************/
+
+    /// @notice A node was registered and is allowed to unlock Angstrom pools.
+    event NodeRegistered(address indexed node);
+
+    /// @notice A node was deregistered and is no longer able to unlock Angstrom pools.
+    event NodeDeregistered(address indexed node);
+
+    /***************************************************************************
+                                   Public Functions
+    ***************************************************************************/
+
+    /**
+     * @notice Unlocks the Angstrom network without requiring an operation.
+     * @dev This function is used to manually unlock the Angstrom network. To be able to do that, the node must be
+     * registered as an Angstrom node, and the signature must be valid (i.e., the hash must match the expected value
+     * per EIP-712).
+     *
+     * @param node The node unlocking the Angstrom network
+     * @param signature The signature of the node unlocking the Angstrom network
+     */
+    function unlockWithEmptyAttestation(address node, bytes calldata signature) external;
+
+    /**
+     * @notice Register a node that is allowed to unlock the system.
+     * @param node The node to register
+     */
+    function registerNode(address node) external;
+
+    /**
+     * @notice Unregister a node that is no longer allowed to unlock the system.
+     * @param node The node to unregister
+     */
+    function deregisterNode(address node) external;
+
+    /**
+     * @notice Get the block number the last time this contract was locked.
+     * @dev If it is equal to the current block number, the contract is unlocked.
+     * @return lastUnlockBlockNumber The block number when the contract was last locked
+     */
+    function getLastUnlockBlockNumber() external view returns (uint256);
+
+    /**
+     * @notice Check whether a given account is a registered Angstrom node.
+     * @param account The address being checked for node status
+     * @return isNode True if the address is a registered Angstrom node
+     */
+    function isRegisteredNode(address account) external view returns (bool);
+}
+

--- a/contracts/interfaces/IAngstromBalancer.sol
+++ b/contracts/interfaces/IAngstromBalancer.sol
@@ -8,6 +8,23 @@ pragma solidity ^0.8.24;
  */
 interface IAngstromBalancer {
     /***************************************************************************
+                                       Structs
+    ***************************************************************************/
+
+    /**
+     * @notice Data for ToB (Top of Block) swaps.
+     * @dev This struct contains the information needed to execute swaps on ToB.
+     */
+    struct ToBSwapData {
+        address tokenIn;
+        address tokenOut;
+        uint256 exactAmountIn;
+        uint256 exactAmountOut;
+        address payer;
+        bytes signature;
+    }
+
+    /***************************************************************************
                                        Errors
     ***************************************************************************/
 
@@ -97,4 +114,3 @@ interface IAngstromBalancer {
      */
     function isRegisteredNode(address account) external view returns (bool);
 }
-

--- a/contracts/test/AngstromBalancerMock.sol
+++ b/contracts/test/AngstromBalancerMock.sol
@@ -32,6 +32,10 @@ contract AngstromBalancerMock is AngstromBalancer {
         return _computeDigestSwapExactOut(paths);
     }
 
+    function computeDigestToB(ToBSwapData memory swap) external view returns (bytes32) {
+        return _computeDigestToB(swap);
+    }
+
     function getDigest() external view returns (bytes32) {
         return _getDigest();
     }

--- a/contracts/test/AngstromBalancerMock.sol
+++ b/contracts/test/AngstromBalancerMock.sol
@@ -36,7 +36,7 @@ contract AngstromBalancerMock is AngstromBalancer {
         return _computeDigestToB(swap);
     }
 
-    function getDigest() external view returns (bytes32) {
-        return _getDigest();
+    function computeDigestEmptyAttestation() external view returns (bytes32) {
+        return _computeDigestEmptyAttestation();
     }
 }

--- a/test/foundry/AngstromBalancerUnit.t.sol
+++ b/test/foundry/AngstromBalancerUnit.t.sol
@@ -6,7 +6,7 @@ import "forge-std/Test.sol";
 
 import { IAuthentication } from "@balancer-labs/v3-interfaces/contracts/solidity-utils/helpers/IAuthentication.sol";
 
-import { AngstromBalancer } from "../../contracts/AngstromBalancer.sol";
+import { IAngstromBalancer } from "../../contracts/interfaces/IAngstromBalancer.sol";
 import { BaseAngstromTest } from "./utils/BaseAngstromTest.sol";
 
 contract AngstromBalancerUnitTest is BaseAngstromTest {
@@ -25,13 +25,13 @@ contract AngstromBalancerUnitTest is BaseAngstromTest {
     function testAddNodeAlreadyRegistered() public {
         registerAngstromNode(bob);
         vm.prank(admin);
-        vm.expectRevert(AngstromBalancer.NodeAlreadyRegistered.selector);
+        vm.expectRevert(IAngstromBalancer.NodeAlreadyRegistered.selector);
         angstromBalancer.registerNode(bob);
     }
 
     function testRemoveNodeNotRegistered() public {
         vm.prank(admin);
-        vm.expectRevert(AngstromBalancer.NodeNotRegistered.selector);
+        vm.expectRevert(IAngstromBalancer.NodeNotRegistered.selector);
         angstromBalancer.deregisterNode(bob);
     }
 

--- a/test/foundry/AngstromHook.t.sol
+++ b/test/foundry/AngstromHook.t.sol
@@ -9,7 +9,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ArrayHelpers } from "@balancer-labs/v3-solidity-utils/contracts/test/ArrayHelpers.sol";
 import { FixedPoint } from "@balancer-labs/v3-solidity-utils/contracts/math/FixedPoint.sol";
 
-import { AngstromBalancer } from "../../contracts/AngstromBalancer.sol";
+import { IAngstromBalancer } from "../../contracts/interfaces/IAngstromBalancer.sol";
 import { BaseAngstromTest } from "./utils/BaseAngstromTest.sol";
 
 contract AngstromHookTest is BaseAngstromTest {
@@ -20,7 +20,7 @@ contract AngstromHookTest is BaseAngstromTest {
     ***************************************************************************/
 
     function testOnBeforeSwapNotNode() public {
-        vm.expectRevert(AngstromBalancer.NotNode.selector);
+        vm.expectRevert(IAngstromBalancer.NotNode.selector);
         vm.prank(bob);
         router.swapSingleTokenExactIn(pool, dai, usdc, 1e18, 0, MAX_UINT256, false, bobUserData);
     }
@@ -28,14 +28,14 @@ contract AngstromHookTest is BaseAngstromTest {
     function testOnBeforeSwapCannotSwapWhileLocked() public {
         // If no userData was provided (therefore, no signature), the hook treats as if the user expected the pools to
         // be unlocked.
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         vm.prank(bob);
         router.swapSingleTokenExactIn(pool, dai, usdc, 1e18, 0, MAX_UINT256, false, bytes(""));
     }
 
     function testOnBeforeSwapUnlockDataTooShort() public {
         // If the userData is too short, there's not enough data to represent the ECDSA signature.
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         vm.prank(bob);
         router.swapSingleTokenExactIn(pool, dai, usdc, 1e18, 0, MAX_UINT256, false, bytes("1"));
     }
@@ -46,7 +46,7 @@ contract AngstromHookTest is BaseAngstromTest {
 
         registerAngstromNode(bob);
 
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         vm.prank(bob);
         router.swapSingleTokenExactIn(pool, dai, usdc, 1e18, 0, MAX_UINT256, false, userData);
     }
@@ -69,7 +69,7 @@ contract AngstromHookTest is BaseAngstromTest {
         vm.prank(bob);
         angstromBalancer.unlockWithEmptyAttestation(bob, bobSignature);
 
-        vm.expectRevert(AngstromBalancer.OnlyOncePerBlock.selector);
+        vm.expectRevert(IAngstromBalancer.OnlyOncePerBlock.selector);
         vm.prank(bob);
         angstromBalancer.unlockWithEmptyAttestation(bob, bobSignature);
     }
@@ -85,19 +85,19 @@ contract AngstromHookTest is BaseAngstromTest {
     }
 
     function testOnBeforeAddLiquidityUnbalancedNoSignature() public {
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         vm.prank(alice);
         router.addLiquidityUnbalanced(pool, [FixedPoint.ONE, FixedPoint.ONE].toMemoryArray(), 1e18, false, bytes(""));
     }
 
     function testOnBeforeAddLiquidityUnbalancedUnlockDataTooShort() public {
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         vm.prank(alice);
         router.addLiquidityUnbalanced(pool, [FixedPoint.ONE, FixedPoint.ONE].toMemoryArray(), 1e18, false, bytes("1"));
     }
 
     function testOnBeforeAddLiquidityUnbalancedNotNode() public {
-        vm.expectRevert(AngstromBalancer.NotNode.selector);
+        vm.expectRevert(IAngstromBalancer.NotNode.selector);
         vm.prank(alice);
         router.addLiquidityUnbalanced(
             pool,
@@ -113,7 +113,7 @@ contract AngstromHookTest is BaseAngstromTest {
 
         registerAngstromNode(alice);
 
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         vm.prank(alice);
         router.addLiquidityUnbalanced(pool, [FixedPoint.ONE, FixedPoint.ONE].toMemoryArray(), 1e18, false, userData);
     }
@@ -153,19 +153,19 @@ contract AngstromHookTest is BaseAngstromTest {
     }
 
     function testOnBeforeRemoveLiquidityUnbalancedNoSignature() public {
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         vm.prank(lp);
         router.removeLiquiditySingleTokenExactIn(pool, 1e18, dai, 0.1e18, false, bytes(""));
     }
 
     function testOnBeforeRemoveLiquidityUnbalancedUnlockDataTooShort() public {
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         vm.prank(lp);
         router.removeLiquiditySingleTokenExactIn(pool, 1e18, dai, 0.1e18, false, bytes("1"));
     }
 
     function testOnBeforeRemoveLiquidityUnbalancedNotNode() public {
-        vm.expectRevert(AngstromBalancer.NotNode.selector);
+        vm.expectRevert(IAngstromBalancer.NotNode.selector);
         vm.prank(lp);
         router.removeLiquiditySingleTokenExactIn(pool, 1e18, dai, 0.1e18, false, lpUserData);
     }
@@ -175,7 +175,7 @@ contract AngstromHookTest is BaseAngstromTest {
 
         registerAngstromNode(lp);
 
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         vm.prank(lp);
         router.removeLiquiditySingleTokenExactIn(pool, 1e18, dai, 0.1e18, false, userData);
     }

--- a/test/foundry/AngstromRouter.t.sol
+++ b/test/foundry/AngstromRouter.t.sol
@@ -104,12 +104,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         SwapPathStep[] memory steps = new SwapPathStep[](1);
         steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
         SwapPathExactAmountIn[] memory paths = new SwapPathExactAmountIn[](1);
-        paths[0] = SwapPathExactAmountIn({
-            tokenIn: dai,
-            steps: steps,
-            exactAmountIn: 3e18,
-            minAmountOut: 0
-        });
+        paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 3e18, minAmountOut: 0 });
 
         IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](2);
         tobSwaps[0] = IAngstromBalancer.ToBSwapData({
@@ -139,11 +134,27 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         Balances memory balancesAfter = getBalances(lp);
 
-        assertEq(balancesAfter.lpTokens[usdcIdx], balancesBefore.lpTokens[usdcIdx] + 2e18, "LP USDC balance is not correct");
-        assertEq(balancesAfter.lpTokens[daiIdx], balancesBefore.lpTokens[daiIdx] - 2e18, "LP DAI balance is not correct");
+        assertEq(
+            balancesAfter.lpTokens[usdcIdx],
+            balancesBefore.lpTokens[usdcIdx] + 2e18,
+            "LP USDC balance is not correct"
+        );
+        assertEq(
+            balancesAfter.lpTokens[daiIdx],
+            balancesBefore.lpTokens[daiIdx] - 2e18,
+            "LP DAI balance is not correct"
+        );
 
-        assertEq(balancesAfter.aliceTokens[usdcIdx], balancesBefore.aliceTokens[usdcIdx] + 1e18, "Alice USDC balance is not correct");
-        assertEq(balancesAfter.aliceTokens[daiIdx], balancesBefore.aliceTokens[daiIdx] - 1e18, "Alice DAI balance is not correct");
+        assertEq(
+            balancesAfter.aliceTokens[usdcIdx],
+            balancesBefore.aliceTokens[usdcIdx] + 1e18,
+            "Alice USDC balance is not correct"
+        );
+        assertEq(
+            balancesAfter.aliceTokens[daiIdx],
+            balancesBefore.aliceTokens[daiIdx] - 1e18,
+            "Alice DAI balance is not correct"
+        );
     }
 
     function testQuerySwapExactIn() public {
@@ -314,11 +325,27 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         Balances memory balancesAfter = getBalances(lp);
 
-        assertEq(balancesAfter.lpTokens[usdcIdx], balancesBefore.lpTokens[usdcIdx] + 2e18, "LP USDC balance is not correct");
-        assertEq(balancesAfter.lpTokens[daiIdx], balancesBefore.lpTokens[daiIdx] - 2e18, "LP DAI balance is not correct");
+        assertEq(
+            balancesAfter.lpTokens[usdcIdx],
+            balancesBefore.lpTokens[usdcIdx] + 2e18,
+            "LP USDC balance is not correct"
+        );
+        assertEq(
+            balancesAfter.lpTokens[daiIdx],
+            balancesBefore.lpTokens[daiIdx] - 2e18,
+            "LP DAI balance is not correct"
+        );
 
-        assertEq(balancesAfter.aliceTokens[usdcIdx], balancesBefore.aliceTokens[usdcIdx] + 1e18, "Alice USDC balance is not correct");
-        assertEq(balancesAfter.aliceTokens[daiIdx], balancesBefore.aliceTokens[daiIdx] - 1e18, "Alice DAI balance is not correct");
+        assertEq(
+            balancesAfter.aliceTokens[usdcIdx],
+            balancesBefore.aliceTokens[usdcIdx] + 1e18,
+            "Alice USDC balance is not correct"
+        );
+        assertEq(
+            balancesAfter.aliceTokens[daiIdx],
+            balancesBefore.aliceTokens[daiIdx] - 1e18,
+            "Alice DAI balance is not correct"
+        );
     }
 
     function testQuerySwapExactOut() public {

--- a/test/foundry/AngstromRouter.t.sol
+++ b/test/foundry/AngstromRouter.t.sol
@@ -28,7 +28,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         SwapPathExactAmountIn[] memory paths;
         IAngstromBalancer.ToBSwapData[] memory tobSwaps;
         vm.expectRevert(IAngstromBalancer.NotNode.selector);
-        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactInAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactInAlreadyUnlocked() public {
@@ -41,7 +41,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         vm.expectRevert(IAngstromBalancer.OnlyOncePerBlock.selector);
 
         vm.prank(bob);
-        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactInAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactInAngstromPathDifferentFromSignature() public {
@@ -67,7 +67,7 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         vm.prank(bob);
         vm.expectRevert(IVaultErrors.BalanceNotSettled.selector);
-        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactInAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactInAngstromBlockNumberDifferentFromSignature() public {
@@ -95,7 +95,7 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         vm.prank(bob);
         vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
-        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactInAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactInUnlocksAngstrom() public {
@@ -130,7 +130,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         Balances memory balancesBefore = getBalances(lp);
 
         vm.prank(bob);
-        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactInAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
 
         Balances memory balancesAfter = getBalances(lp);
 
@@ -157,55 +157,11 @@ contract AngstromRouterTest is BaseAngstromTest {
         );
     }
 
-    function testQuerySwapExactIn() public {
-        SwapPathStep[] memory steps = new SwapPathStep[](1);
-        steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
-        SwapPathExactAmountIn[] memory paths = new SwapPathExactAmountIn[](1);
-        paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 1e18, minAmountOut: 0 });
-
-        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](1);
-        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
-            tokenIn: address(dai),
-            tokenOut: address(usdc),
-            exactAmountIn: 1e18,
-            exactAmountOut: 1e18,
-            payer: alice,
-            signature: bytes("")
-        });
-
-        uint256 snapId = vm.snapshot();
-        _prankStaticCall();
-        (
-            uint256[] memory pathAmountsOutQuery,
-            address[] memory tokensOutQuery,
-            uint256[] memory amountsOutQuery
-        ) = angstromBalancer.querySwapExactIn(paths, bob, bytes(""));
-        vm.revertTo(snapId);
-
-        registerAngstromNode(bob);
-
-        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
-
-        vm.prank(bob);
-        (uint256[] memory pathAmountsOut, address[] memory tokensOut, uint256[] memory amountsOut) = angstromBalancer
-            .swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
-
-        assertEq(pathAmountsOut.length, pathAmountsOutQuery.length, "Path amounts out length is not equal");
-        assertEq(tokensOut.length, tokensOutQuery.length, "Tokens out length is not equal");
-        assertEq(amountsOut.length, amountsOutQuery.length, "Amounts out length is not equal");
-
-        for (uint256 i = 0; i < pathAmountsOut.length; i++) {
-            assertEq(pathAmountsOut[i], pathAmountsOutQuery[i], "Path amounts out is not equal");
-            assertEq(tokensOut[i], tokensOutQuery[i], "Tokens out is not equal");
-            assertEq(amountsOut[i], amountsOutQuery[i], "Amounts out is not equal");
-        }
-    }
-
     function testSwapExactOutNotNode() public {
         SwapPathExactAmountOut[] memory paths;
         IAngstromBalancer.ToBSwapData[] memory tobSwaps;
         vm.expectRevert(IAngstromBalancer.NotNode.selector);
-        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactOutAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactOutAlreadyUnlocked() public {
@@ -218,7 +174,7 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         vm.expectRevert(IAngstromBalancer.OnlyOncePerBlock.selector);
         vm.prank(bob);
-        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactOutAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactOutAngstromPathDifferentFromSignature() public {
@@ -249,7 +205,7 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         vm.prank(bob);
         vm.expectRevert(IVaultErrors.BalanceNotSettled.selector);
-        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactOutAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactOutAngstromBlockNumberDifferentFromSignature() public {
@@ -281,7 +237,7 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         vm.prank(bob);
         vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
-        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactOutAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactOutUnlocksRouter() public {
@@ -321,7 +277,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         Balances memory balancesBefore = getBalances(lp);
 
         vm.prank(bob);
-        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactOutAngstrom(paths, tobSwaps, MAX_UINT256, false, bytes(""));
 
         Balances memory balancesAfter = getBalances(lp);
 
@@ -346,54 +302,6 @@ contract AngstromRouterTest is BaseAngstromTest {
             balancesBefore.aliceTokens[daiIdx] - 1e18,
             "Alice DAI balance is not correct"
         );
-    }
-
-    function testQuerySwapExactOut() public {
-        SwapPathStep[] memory steps = new SwapPathStep[](1);
-        steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
-        SwapPathExactAmountOut[] memory paths = new SwapPathExactAmountOut[](1);
-        paths[0] = SwapPathExactAmountOut({
-            tokenIn: dai,
-            steps: steps,
-            exactAmountOut: 1e18,
-            maxAmountIn: MAX_UINT256
-        });
-        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](1);
-        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
-            tokenIn: address(dai),
-            tokenOut: address(usdc),
-            exactAmountIn: 1e18,
-            exactAmountOut: 1e18,
-            payer: alice,
-            signature: bytes("")
-        });
-
-        uint256 snapId = vm.snapshot();
-        _prankStaticCall();
-        (
-            uint256[] memory pathAmountsInQuery,
-            address[] memory tokensInQuery,
-            uint256[] memory amountsInQuery
-        ) = angstromBalancer.querySwapExactOut(paths, bob, bytes(""));
-        vm.revertTo(snapId);
-
-        registerAngstromNode(bob);
-
-        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
-
-        vm.prank(bob);
-        (uint256[] memory pathAmountsIn, address[] memory tokensIn, uint256[] memory amountsIn) = angstromBalancer
-            .swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
-
-        assertEq(pathAmountsIn.length, pathAmountsInQuery.length, "Path amounts in length is not equal");
-        assertEq(tokensIn.length, tokensInQuery.length, "Tokens in length is not equal");
-        assertEq(amountsIn.length, amountsInQuery.length, "Amounts in length is not equal");
-
-        for (uint256 i = 0; i < pathAmountsIn.length; i++) {
-            assertEq(pathAmountsIn[i], pathAmountsInQuery[i], "Path amounts in is not equal");
-            assertEq(tokensIn[i], tokensInQuery[i], "Tokens in is not equal");
-            assertEq(amountsIn[i], amountsInQuery[i], "Amounts in is not equal");
-        }
     }
 
     function _approveAngstromRouterForAllUsers() private {

--- a/test/foundry/AngstromRouter.t.sol
+++ b/test/foundry/AngstromRouter.t.sol
@@ -98,24 +98,53 @@ contract AngstromRouterTest is BaseAngstromTest {
         angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
-    // TODO Refactor this test ot multiple users
-    // function testSwapExactInUnlocksAngstrom() public {
-    //     registerAngstromNode(bob);
+    function testSwapExactInUnlocksAngstrom() public {
+        registerAngstromNode(bob);
 
-    //     SwapPathExactAmountIn[] memory paths;
-    //     IAngstromBalancer.ToBSwapData[] memory tobSwaps;
+        SwapPathStep[] memory steps = new SwapPathStep[](1);
+        steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
+        SwapPathExactAmountIn[] memory paths = new SwapPathExactAmountIn[](1);
+        paths[0] = SwapPathExactAmountIn({
+            tokenIn: dai,
+            steps: steps,
+            exactAmountIn: 3e18,
+            minAmountOut: 0
+        });
 
-    //     bytes memory userData = generateSignatureToBSwap(aliceKey, paths);
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](2);
+        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 1e18,
+            exactAmountOut: 1e18,
+            payer: alice,
+            signature: bytes("")
+        });
+        tobSwaps[1] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 2e18,
+            exactAmountOut: 2e18,
+            payer: lp,
+            signature: bytes("")
+        });
 
-    //     vm.prank(bob);
-    //     angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, userData);
+        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
+        tobSwaps[1].signature = generateSignatureToBSwap(lpKey, tobSwaps[1]);
 
-    //     assertEq(
-    //         angstromBalancer.getLastUnlockBlockNumber(),
-    //         block.number,
-    //         "Last unlock block number is not the current block number"
-    //     );
-    // }
+        Balances memory balancesBefore = getBalances(lp);
+
+        vm.prank(bob);
+        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+
+        Balances memory balancesAfter = getBalances(lp);
+
+        assertEq(balancesAfter.lpTokens[usdcIdx], balancesBefore.lpTokens[usdcIdx] + 2e18, "LP USDC balance is not correct");
+        assertEq(balancesAfter.lpTokens[daiIdx], balancesBefore.lpTokens[daiIdx] - 2e18, "LP DAI balance is not correct");
+
+        assertEq(balancesAfter.aliceTokens[usdcIdx], balancesBefore.aliceTokens[usdcIdx] + 1e18, "Alice USDC balance is not correct");
+        assertEq(balancesAfter.aliceTokens[daiIdx], balancesBefore.aliceTokens[daiIdx] - 1e18, "Alice DAI balance is not correct");
+    }
 
     function testQuerySwapExactIn() public {
         SwapPathStep[] memory steps = new SwapPathStep[](1);
@@ -244,24 +273,53 @@ contract AngstromRouterTest is BaseAngstromTest {
         angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
-    // TODO Refactor this test ot multiple users
-    // function testSwapExactOutUnlocksRouter() public {
-    //     registerAngstromNode(bob);
+    function testSwapExactOutUnlocksRouter() public {
+        registerAngstromNode(bob);
 
-    //     SwapPathExactAmountOut[] memory paths;
-    //     IAngstromBalancer.ToBSwapData[] memory tobSwaps;
+        SwapPathStep[] memory steps = new SwapPathStep[](1);
+        steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
+        SwapPathExactAmountOut[] memory paths = new SwapPathExactAmountOut[](1);
+        paths[0] = SwapPathExactAmountOut({
+            tokenIn: dai,
+            steps: steps,
+            exactAmountOut: 3e18,
+            maxAmountIn: MAX_UINT256
+        });
 
-    //     (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](2);
+        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 1e18,
+            exactAmountOut: 1e18,
+            payer: alice,
+            signature: bytes("")
+        });
+        tobSwaps[1] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 2e18,
+            exactAmountOut: 2e18,
+            payer: lp,
+            signature: bytes("")
+        });
 
-    //     vm.prank(bob);
-    //     angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, userData);
+        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
+        tobSwaps[1].signature = generateSignatureToBSwap(lpKey, tobSwaps[1]);
 
-    //     assertEq(
-    //         angstromBalancer.getLastUnlockBlockNumber(),
-    //         block.number,
-    //         "Last unlock block number is not the current block number"
-    //     );
-    // }
+        Balances memory balancesBefore = getBalances(lp);
+
+        vm.prank(bob);
+        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
+
+        Balances memory balancesAfter = getBalances(lp);
+
+        assertEq(balancesAfter.lpTokens[usdcIdx], balancesBefore.lpTokens[usdcIdx] + 2e18, "LP USDC balance is not correct");
+        assertEq(balancesAfter.lpTokens[daiIdx], balancesBefore.lpTokens[daiIdx] - 2e18, "LP DAI balance is not correct");
+
+        assertEq(balancesAfter.aliceTokens[usdcIdx], balancesBefore.aliceTokens[usdcIdx] + 1e18, "Alice USDC balance is not correct");
+        assertEq(balancesAfter.aliceTokens[daiIdx], balancesBefore.aliceTokens[daiIdx] - 1e18, "Alice DAI balance is not correct");
+    }
 
     function testQuerySwapExactOut() public {
         SwapPathStep[] memory steps = new SwapPathStep[](1);

--- a/test/foundry/AngstromRouter.t.sol
+++ b/test/foundry/AngstromRouter.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { IVaultErrors } from "@balancer-labs/v3-interfaces/contracts/vault/IVaultErrors.sol";
 import {
     SwapPathExactAmountIn,
     SwapPathExactAmountOut,
@@ -25,30 +26,22 @@ contract AngstromRouterTest is BaseAngstromTest {
 
     function testSwapExactInNotNode() public {
         SwapPathExactAmountIn[] memory paths;
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps;
         vm.expectRevert(IAngstromBalancer.NotNode.selector);
-        angstromBalancer.swapExactIn(paths, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactInAlreadyUnlocked() public {
         registerAngstromNode(bob);
 
         SwapPathExactAmountIn[] memory paths;
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps;
 
         angstromBalancer.manualUnlockAngstrom();
         vm.expectRevert(IAngstromBalancer.OnlyOncePerBlock.selector);
 
         vm.prank(bob);
-        angstromBalancer.swapExactIn(paths, MAX_UINT256, false, bytes(""));
-    }
-
-    function testSwapExactInAngstromWithoutSignature() public {
-        registerAngstromNode(bob);
-
-        SwapPathExactAmountIn[] memory paths;
-
-        vm.prank(bob);
-        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
-        angstromBalancer.swapExactIn(paths, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactInAngstromPathDifferentFromSignature() public {
@@ -57,15 +50,24 @@ contract AngstromRouterTest is BaseAngstromTest {
         SwapPathStep[] memory steps = new SwapPathStep[](1);
         steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
         SwapPathExactAmountIn[] memory paths = new SwapPathExactAmountIn[](1);
-        paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 1e18, minAmountOut: 0 });
-
-        (, bytes memory userData) = generateSignatureAndUserDataSwapExactIn(alice, aliceKey, paths);
-
         paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 1.01e18, minAmountOut: 0 });
 
+        // Path amountIn is different from signature.
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](1);
+        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 1e18,
+            exactAmountOut: 1e18,
+            payer: alice,
+            signature: bytes("")
+        });
+
+        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
+
         vm.prank(bob);
-        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
-        angstromBalancer.swapExactIn(paths, MAX_UINT256, false, userData);
+        vm.expectRevert(IVaultErrors.BalanceNotSettled.selector);
+        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactInAngstromBlockNumberDifferentFromSignature() public {
@@ -75,38 +77,61 @@ contract AngstromRouterTest is BaseAngstromTest {
         steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
         SwapPathExactAmountIn[] memory paths = new SwapPathExactAmountIn[](1);
         paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 1e18, minAmountOut: 0 });
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](1);
 
-        (, bytes memory userData) = generateSignatureAndUserDataSwapExactIn(alice, aliceKey, paths);
+        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 1e18,
+            exactAmountOut: 1e18,
+            payer: alice,
+            signature: bytes("")
+        });
+
+        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
+
         // Moving block number should invalidate signature
         vm.roll(block.number + 1);
 
         vm.prank(bob);
         vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
-        angstromBalancer.swapExactIn(paths, MAX_UINT256, false, userData);
+        angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
-    function testSwapExactInUnlocksAngstrom() public {
-        registerAngstromNode(bob);
+    // TODO Refactor this test ot multiple users
+    // function testSwapExactInUnlocksAngstrom() public {
+    //     registerAngstromNode(bob);
 
-        SwapPathExactAmountIn[] memory paths;
+    //     SwapPathExactAmountIn[] memory paths;
+    //     IAngstromBalancer.ToBSwapData[] memory tobSwaps;
 
-        (, bytes memory userData) = generateSignatureAndUserDataSwapExactIn(alice, aliceKey, paths);
+    //     bytes memory userData = generateSignatureToBSwap(aliceKey, paths);
 
-        vm.prank(bob);
-        angstromBalancer.swapExactIn(paths, MAX_UINT256, false, userData);
+    //     vm.prank(bob);
+    //     angstromBalancer.swapExactIn(paths, tobSwaps, MAX_UINT256, false, userData);
 
-        assertEq(
-            angstromBalancer.getLastUnlockBlockNumber(),
-            block.number,
-            "Last unlock block number is not the current block number"
-        );
-    }
+    //     assertEq(
+    //         angstromBalancer.getLastUnlockBlockNumber(),
+    //         block.number,
+    //         "Last unlock block number is not the current block number"
+    //     );
+    // }
 
     function testQuerySwapExactIn() public {
         SwapPathStep[] memory steps = new SwapPathStep[](1);
         steps[0] = SwapPathStep({ pool: pool, tokenOut: usdc, isBuffer: false });
         SwapPathExactAmountIn[] memory paths = new SwapPathExactAmountIn[](1);
         paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 1e18, minAmountOut: 0 });
+
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](1);
+        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 1e18,
+            exactAmountOut: 1e18,
+            payer: alice,
+            signature: bytes("")
+        });
 
         uint256 snapId = vm.snapshot();
         _prankStaticCall();
@@ -119,11 +144,11 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         registerAngstromNode(bob);
 
-        (, bytes memory userData) = generateSignatureAndUserDataSwapExactIn(alice, aliceKey, paths);
+        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
 
         vm.prank(bob);
         (uint256[] memory pathAmountsOut, address[] memory tokensOut, uint256[] memory amountsOut) = angstromBalancer
-            .swapExactIn(paths, MAX_UINT256, false, userData);
+            .swapExactIn(paths, tobSwaps, MAX_UINT256, false, bytes(""));
 
         assertEq(pathAmountsOut.length, pathAmountsOutQuery.length, "Path amounts out length is not equal");
         assertEq(tokensOut.length, tokensOutQuery.length, "Tokens out length is not equal");
@@ -138,30 +163,22 @@ contract AngstromRouterTest is BaseAngstromTest {
 
     function testSwapExactOutNotNode() public {
         SwapPathExactAmountOut[] memory paths;
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps;
         vm.expectRevert(IAngstromBalancer.NotNode.selector);
-        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactOutAlreadyUnlocked() public {
         registerAngstromNode(bob);
 
         SwapPathExactAmountOut[] memory paths;
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps;
 
         angstromBalancer.manualUnlockAngstrom();
 
         vm.expectRevert(IAngstromBalancer.OnlyOncePerBlock.selector);
         vm.prank(bob);
-        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, bytes(""));
-    }
-
-    function testSwapExactOutAngstromWithoutSignature() public {
-        registerAngstromNode(bob);
-
-        SwapPathExactAmountOut[] memory paths;
-
-        vm.prank(bob);
-        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
-        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, bytes(""));
+        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactOutAngstromPathDifferentFromSignature() public {
@@ -173,22 +190,26 @@ contract AngstromRouterTest is BaseAngstromTest {
         paths[0] = SwapPathExactAmountOut({
             tokenIn: dai,
             steps: steps,
+            exactAmountOut: 0.99e18,
+            maxAmountIn: MAX_UINT256
+        });
+
+        // Path amountOut is different from signature.
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](1);
+        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 1e18,
             exactAmountOut: 1e18,
-            maxAmountIn: MAX_UINT256
+            payer: alice,
+            signature: bytes("")
         });
 
-        (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
-
-        paths[0] = SwapPathExactAmountOut({
-            tokenIn: dai,
-            steps: steps,
-            exactAmountOut: 1.01e18,
-            maxAmountIn: MAX_UINT256
-        });
+        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
 
         vm.prank(bob);
-        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
-        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, userData);
+        vm.expectRevert(IVaultErrors.BalanceNotSettled.selector);
+        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
     function testSwapExactOutAngstromBlockNumberDifferentFromSignature() public {
@@ -203,32 +224,44 @@ contract AngstromRouterTest is BaseAngstromTest {
             exactAmountOut: 1e18,
             maxAmountIn: MAX_UINT256
         });
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](1);
+        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 1e18,
+            exactAmountOut: 1e18,
+            payer: alice,
+            signature: bytes("")
+        });
 
-        (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
+        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
+
         // Moving block number should invalidate signature
         vm.roll(block.number + 1);
 
         vm.prank(bob);
         vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
-        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, userData);
+        angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
     }
 
-    function testSwapExactOutUnlocksRouter() public {
-        registerAngstromNode(bob);
+    // TODO Refactor this test ot multiple users
+    // function testSwapExactOutUnlocksRouter() public {
+    //     registerAngstromNode(bob);
 
-        SwapPathExactAmountOut[] memory paths;
+    //     SwapPathExactAmountOut[] memory paths;
+    //     IAngstromBalancer.ToBSwapData[] memory tobSwaps;
 
-        (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
+    //     (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
 
-        vm.prank(bob);
-        angstromBalancer.swapExactOut(paths, MAX_UINT256, false, userData);
+    //     vm.prank(bob);
+    //     angstromBalancer.swapExactOut(paths, tobSwaps, MAX_UINT256, false, userData);
 
-        assertEq(
-            angstromBalancer.getLastUnlockBlockNumber(),
-            block.number,
-            "Last unlock block number is not the current block number"
-        );
-    }
+    //     assertEq(
+    //         angstromBalancer.getLastUnlockBlockNumber(),
+    //         block.number,
+    //         "Last unlock block number is not the current block number"
+    //     );
+    // }
 
     function testQuerySwapExactOut() public {
         SwapPathStep[] memory steps = new SwapPathStep[](1);
@@ -239,6 +272,15 @@ contract AngstromRouterTest is BaseAngstromTest {
             steps: steps,
             exactAmountOut: 1e18,
             maxAmountIn: MAX_UINT256
+        });
+        IAngstromBalancer.ToBSwapData[] memory tobSwaps = new IAngstromBalancer.ToBSwapData[](1);
+        tobSwaps[0] = IAngstromBalancer.ToBSwapData({
+            tokenIn: address(dai),
+            tokenOut: address(usdc),
+            exactAmountIn: 1e18,
+            exactAmountOut: 1e18,
+            payer: alice,
+            signature: bytes("")
         });
 
         uint256 snapId = vm.snapshot();
@@ -252,11 +294,11 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         registerAngstromNode(bob);
 
-        (, bytes memory userData) = generateSignatureAndUserDataSwapExactOut(alice, aliceKey, paths);
+        tobSwaps[0].signature = generateSignatureToBSwap(aliceKey, tobSwaps[0]);
 
         vm.prank(bob);
         (uint256[] memory pathAmountsIn, address[] memory tokensIn, uint256[] memory amountsIn) = angstromBalancer
-            .swapExactOut(paths, MAX_UINT256, false, userData);
+            .swapExactOut(paths, tobSwaps, MAX_UINT256, false, bytes(""));
 
         assertEq(pathAmountsIn.length, pathAmountsInQuery.length, "Path amounts in length is not equal");
         assertEq(tokensIn.length, tokensInQuery.length, "Tokens in length is not equal");

--- a/test/foundry/AngstromRouter.t.sol
+++ b/test/foundry/AngstromRouter.t.sol
@@ -12,7 +12,7 @@ import {
     SwapPathStep
 } from "@balancer-labs/v3-interfaces/contracts/vault/BatchRouterTypes.sol";
 
-import { AngstromBalancer } from "../../contracts/AngstromBalancer.sol";
+import { IAngstromBalancer } from "../../contracts/interfaces/IAngstromBalancer.sol";
 import { BaseAngstromTest } from "./utils/BaseAngstromTest.sol";
 
 contract AngstromRouterTest is BaseAngstromTest {
@@ -25,7 +25,7 @@ contract AngstromRouterTest is BaseAngstromTest {
 
     function testSwapExactInNotNode() public {
         SwapPathExactAmountIn[] memory paths;
-        vm.expectRevert(AngstromBalancer.NotNode.selector);
+        vm.expectRevert(IAngstromBalancer.NotNode.selector);
         angstromBalancer.swapExactIn(paths, MAX_UINT256, false, bytes(""));
     }
 
@@ -35,7 +35,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         SwapPathExactAmountIn[] memory paths;
 
         angstromBalancer.manualUnlockAngstrom();
-        vm.expectRevert(AngstromBalancer.OnlyOncePerBlock.selector);
+        vm.expectRevert(IAngstromBalancer.OnlyOncePerBlock.selector);
 
         vm.prank(bob);
         angstromBalancer.swapExactIn(paths, MAX_UINT256, false, bytes(""));
@@ -47,7 +47,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         SwapPathExactAmountIn[] memory paths;
 
         vm.prank(bob);
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         angstromBalancer.swapExactIn(paths, MAX_UINT256, false, bytes(""));
     }
 
@@ -64,7 +64,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         paths[0] = SwapPathExactAmountIn({ tokenIn: dai, steps: steps, exactAmountIn: 1.01e18, minAmountOut: 0 });
 
         vm.prank(bob);
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         angstromBalancer.swapExactIn(paths, MAX_UINT256, false, userData);
     }
 
@@ -81,7 +81,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         vm.roll(block.number + 1);
 
         vm.prank(bob);
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         angstromBalancer.swapExactIn(paths, MAX_UINT256, false, userData);
     }
 
@@ -138,7 +138,7 @@ contract AngstromRouterTest is BaseAngstromTest {
 
     function testSwapExactOutNotNode() public {
         SwapPathExactAmountOut[] memory paths;
-        vm.expectRevert(AngstromBalancer.NotNode.selector);
+        vm.expectRevert(IAngstromBalancer.NotNode.selector);
         angstromBalancer.swapExactOut(paths, MAX_UINT256, false, bytes(""));
     }
 
@@ -149,7 +149,7 @@ contract AngstromRouterTest is BaseAngstromTest {
 
         angstromBalancer.manualUnlockAngstrom();
 
-        vm.expectRevert(AngstromBalancer.OnlyOncePerBlock.selector);
+        vm.expectRevert(IAngstromBalancer.OnlyOncePerBlock.selector);
         vm.prank(bob);
         angstromBalancer.swapExactOut(paths, MAX_UINT256, false, bytes(""));
     }
@@ -160,7 +160,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         SwapPathExactAmountOut[] memory paths;
 
         vm.prank(bob);
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         angstromBalancer.swapExactOut(paths, MAX_UINT256, false, bytes(""));
     }
 
@@ -187,7 +187,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         });
 
         vm.prank(bob);
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         angstromBalancer.swapExactOut(paths, MAX_UINT256, false, userData);
     }
 
@@ -209,7 +209,7 @@ contract AngstromRouterTest is BaseAngstromTest {
         vm.roll(block.number + 1);
 
         vm.prank(bob);
-        vm.expectRevert(AngstromBalancer.InvalidSignature.selector);
+        vm.expectRevert(IAngstromBalancer.InvalidSignature.selector);
         angstromBalancer.swapExactOut(paths, MAX_UINT256, false, userData);
     }
 

--- a/test/foundry/utils/BaseAngstromTest.sol
+++ b/test/foundry/utils/BaseAngstromTest.sol
@@ -79,7 +79,7 @@ contract BaseAngstromTest is BaseVaultTest {
         address signer,
         uint256 privateKey
     ) internal view returns (bytes memory signature, bytes memory userData) {
-        bytes32 hash = angstromBalancer.getDigest();
+        bytes32 hash = angstromBalancer.computeDigestEmptyAttestation();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, hash);
         signature = abi.encodePacked(r, s, v);
         userData = abi.encodePacked(signer, signature);

--- a/test/foundry/utils/BaseAngstromTest.sol
+++ b/test/foundry/utils/BaseAngstromTest.sol
@@ -25,12 +25,17 @@ contract BaseAngstromTest is BaseVaultTest {
     bytes internal lpSignature;
     bytes internal lpUserData;
 
+    uint256 internal usdcIdx;
+    uint256 internal daiIdx;
+
     function setUp() public virtual override {
         BaseVaultTest.setUp();
 
         (aliceSignature, aliceUserData) = generateSignatureAndUserDataEmptyAttestation(alice, aliceKey);
         (bobSignature, bobUserData) = generateSignatureAndUserDataEmptyAttestation(bob, bobKey);
         (lpSignature, lpUserData) = generateSignatureAndUserDataEmptyAttestation(lp, lpKey);
+    
+        (usdcIdx, daiIdx) = getSortedIndexes(address(usdc), address(dai));
     }
 
     function createHook() internal override returns (address) {

--- a/test/foundry/utils/BaseAngstromTest.sol
+++ b/test/foundry/utils/BaseAngstromTest.sol
@@ -8,8 +8,8 @@ import "@balancer-labs/v3-interfaces/contracts/vault/BatchRouterTypes.sol";
 
 import { BaseVaultTest } from "@balancer-labs/v3-vault/test/foundry/utils/BaseVaultTest.sol";
 
+import { IAngstromBalancer } from "../../../contracts/interfaces/IAngstromBalancer.sol";
 import { AngstromBalancerMock } from "../../../contracts/test/AngstromBalancerMock.sol";
-import { AngstromBalancer } from "../../../contracts/AngstromBalancer.sol";
 
 contract BaseAngstromTest is BaseVaultTest {
     string private artifactsRootDir = "artifacts/";
@@ -54,7 +54,7 @@ contract BaseAngstromTest is BaseVaultTest {
 
     function registerAngstromNode(address account) internal {
         vm.expectEmit();
-        emit AngstromBalancer.NodeRegistered(account);
+        emit IAngstromBalancer.NodeRegistered(account);
 
         vm.prank(admin);
         angstromBalancer.registerNode(account);
@@ -63,7 +63,7 @@ contract BaseAngstromTest is BaseVaultTest {
 
     function deregisterAngstromNode(address account) internal {
         vm.expectEmit();
-        emit AngstromBalancer.NodeDeregistered(account);
+        emit IAngstromBalancer.NodeDeregistered(account);
 
         vm.prank(admin);
         angstromBalancer.deregisterNode(account);

--- a/test/foundry/utils/BaseAngstromTest.sol
+++ b/test/foundry/utils/BaseAngstromTest.sol
@@ -102,6 +102,15 @@ contract BaseAngstromTest is BaseVaultTest {
         userData = abi.encodePacked(signer, signature);
     }
 
+    function generateSignatureToBSwap(
+        uint256 privateKey,
+        IAngstromBalancer.ToBSwapData memory swap
+    ) internal view returns (bytes memory signature) {
+        bytes32 hash = angstromBalancer.computeDigestToB(swap);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, hash);
+        signature = abi.encodePacked(r, s, v);
+    }
+
     function _computeAngstromBalancerTestPath(string memory name) private view returns (string memory) {
         return string(abi.encodePacked(artifactsRootDir, "contracts/test/", name, ".sol/", name, ".json"));
     }

--- a/test/foundry/utils/BaseAngstromTest.sol
+++ b/test/foundry/utils/BaseAngstromTest.sol
@@ -34,7 +34,7 @@ contract BaseAngstromTest is BaseVaultTest {
         (aliceSignature, aliceUserData) = generateSignatureAndUserDataEmptyAttestation(alice, aliceKey);
         (bobSignature, bobUserData) = generateSignatureAndUserDataEmptyAttestation(bob, bobKey);
         (lpSignature, lpUserData) = generateSignatureAndUserDataEmptyAttestation(lp, lpKey);
-    
+
         (usdcIdx, daiIdx) = getSortedIndexes(address(usdc), address(dai));
     }
 


### PR DESCRIPTION
# Description

`swapExactIn` and `swapExactOut` need to support multiple ToB traders. These traders know exactly how much they'll pay and how much they'll receive in the transaction, so there's no minimum and maximum limits, only exact amounts.

The pathsToB swap aggregates all ToB swaps and the resulting swaps need to match perfectly the sum of ToB orders.

Notice that the test coverage is not 100% anymore. That's because the user signtures are not used. However, in the next PR, a support to user swaps that come after ToB swaps will be added, so these signatures were kept in the code.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

Closes #8 
